### PR TITLE
Stops scrollTo from breaking when swiping back from first page and then pressing next button

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -271,6 +271,29 @@ module.exports = _reactNative2.default.createClass({
     });
   },
 
+  /*
+   * Drag end handle
+   * @param {object} e native event
+   */
+  onScrollEndDrag: function onScrollEndDrag(e) {
+    var contentOffset = e.nativeEvent.contentOffset;
+    var _props = this.props;
+    var horizontal = _props.horizontal;
+    var children = _props.children;
+    var _state = this.state;
+    var offset = _state.offset;
+    var index = _state.index;
+
+    var previousOffset = horizontal ? offset.x : offset.y;
+    var newOffset = horizontal ? contentOffset.x : contentOffset.y;
+
+    if (previousOffset === newOffset && (index === 0 || index === children.length - 1)) {
+      this.setState({
+        isScrolling: false
+      });
+    }
+  },
+
   /**
    * Update index after scroll
    * @param  {object} offset content offset
@@ -442,7 +465,8 @@ module.exports = _reactNative2.default.createClass({
         contentContainerStyle: [styles.wrapper, this.props.style],
         contentOffset: this.state.offset,
         onScrollBeginDrag: this.onScrollBegin,
-        onMomentumScrollEnd: this.onScrollEnd }),
+        onMomentumScrollEnd: this.onScrollEnd,
+        onScrollEndDrag: this.onScrollEndDrag }),
       pages
     );
     return _reactNative2.default.createElement(

--- a/src/index.js
+++ b/src/index.js
@@ -270,6 +270,24 @@ module.exports = React.createClass({
     })
   },
 
+  /*
+   * Drag end handle
+   * @param {object} e native event
+   */
+  onScrollEndDrag(e) {
+    let { contentOffset } = e.nativeEvent
+    let { horizontal, children } = this.props
+    let { offset, index } = this.state
+    let previousOffset = horizontal ? offset.x : offset.y
+    let newOffset = horizontal ? contentOffset.x : contentOffset.y
+    
+    if (previousOffset === newOffset && (index === 0 || index === children.length - 1)) {
+      this.setState({
+        isScrolling: false
+      })
+    }
+  },
+
   /**
    * Update index after scroll
    * @param  {object} offset content offset
@@ -433,7 +451,8 @@ module.exports = React.createClass({
                        contentContainerStyle={[styles.wrapper, this.props.style]}
                        contentOffset={this.state.offset}
                        onScrollBeginDrag={this.onScrollBegin}
-                       onMomentumScrollEnd={this.onScrollEnd}>
+                       onMomentumScrollEnd={this.onScrollEnd}
+                       onScrollEndDrag={this.onScrollEndDrag}>
              {pages}
             </ScrollView>
          );


### PR DESCRIPTION
Fixes issue #41 (and potentially #17, but not totally sure on that one) where if you attempt to swipe back from the first page, or forward from the last page it breaks the scrollTo function. This happens because `this.state.isScrolling` is currently never reset to false  when the users stop swiping because the `onScrollEnd` function is never called when the user does the afore mentioned actions.