### PR TITLE
Add ability to set custom boundary views for loop

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -128,7 +128,9 @@ module.exports = _reactNative2.default.createClass({
     autoplayTimeout: _reactNative2.default.PropTypes.number,
     autoplayDirection: _reactNative2.default.PropTypes.bool,
     index: _reactNative2.default.PropTypes.number,
-    renderPagination: _reactNative2.default.PropTypes.func
+    renderPagination: _reactNative2.default.PropTypes.func,
+    renderLeftLoopView: _reactNative2.default.PropTypes.func,
+    renderRightLoopView: _reactNative2.default.PropTypes.func
   },
 
   mixins: [_reactTimerMixin2.default],
@@ -197,7 +199,7 @@ module.exports = _reactNative2.default.createClass({
     initState.offset = {};
 
     if (initState.total > 1) {
-      var setup = props.loop ? 1 : initState.index;
+      var setup = props.loop ? initState.index + 1 : initState.index;
       initState.offset[initState.dir] = initState.dir == 'y' ? initState.height * setup : initState.width * setup;
     }
     return initState;
@@ -472,7 +474,7 @@ module.exports = _reactNative2.default.createClass({
 
     for (var prop in props) {
       // if(~scrollResponders.indexOf(prop)
-      if (typeof props[prop] === 'function' && prop !== 'onMomentumScrollEnd' && prop !== 'renderPagination' && prop !== 'onScrollBeginDrag') {
+      if (typeof props[prop] === 'function' && prop !== 'onMomentumScrollEnd' && prop !== 'renderPagination' && prop !== 'onScrollBeginDrag' && prop !== 'renderLeftLoopView' && prop !== 'renderRightLoopView') {
         (function () {
           var originResponder = props[prop];
           props[prop] = function (e) {
@@ -490,6 +492,8 @@ module.exports = _reactNative2.default.createClass({
    * @return {object} react-dom
    */
   render: function render() {
+    var _this7 = this;
+
     var state = this.state;
     var props = this.props;
     var children = props.children;
@@ -504,21 +508,37 @@ module.exports = _reactNative2.default.createClass({
 
     // For make infinite at least total > 1
     if (total > 1) {
+      (function () {
 
-      // Re-design a loop model for avoid img flickering
-      pages = Object.keys(children);
-      if (loop) {
-        pages.unshift(total - 1);
-        pages.push(0);
-      }
+        // Re-design a loop model for avoid img flickering
+        pages = Object.keys(children);
+        var loopBoundaryViewsIncluded = _this7.props.renderLeftLoopView && _this7.props.renderRightLoopView;
+        if (loop && !loopBoundaryViewsIncluded) {
+          pages.unshift(total - 1);
+          pages.push(0);
+        }
 
-      pages = pages.map(function (page, i) {
-        return _reactNative2.default.createElement(
-          _reactNative.View,
-          { style: pageStyle, key: i },
-          children[page]
-        );
-      });
+        pages = pages.map(function (page, i) {
+          return _reactNative2.default.createElement(
+            _reactNative.View,
+            { style: pageStyle, key: i + (loopBoundaryViewsIncluded || 0) },
+            children[page]
+          );
+        });
+
+        if (loopBoundaryViewsIncluded) {
+          pages.unshift(_reactNative2.default.createElement(
+            _reactNative.View,
+            { style: pageStyle, key: 0 },
+            _this7.props.renderLeftLoopView()
+          ));
+          pages.push(_reactNative2.default.createElement(
+            _reactNative.View,
+            { style: pageStyle, key: total + 1 },
+            _this7.props.renderRightLoopView()
+          ));
+        }
+      })();
     } else pages = _reactNative2.default.createElement(
       _reactNative.View,
       { style: pageStyle },

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,8 @@ module.exports = React.createClass({
     autoplayDirection                : React.PropTypes.bool,
     index                            : React.PropTypes.number,
     renderPagination                 : React.PropTypes.func,
+    renderLeftLoopView               : React.PropTypes.func,
+    renderRightLoopView              : React.PropTypes.func,
   },
 
   mixins: [TimerMixin],
@@ -194,7 +196,7 @@ module.exports = React.createClass({
     initState.offset = {}
 
     if (initState.total > 1) {
-      var setup = props.loop ? 1 : initState.index
+      var setup = props.loop ? (initState.index + 1) : initState.index
       initState.offset[initState.dir] = initState.dir == 'y'
         ? initState.height * setup
         : initState.width * setup
@@ -465,6 +467,8 @@ module.exports = React.createClass({
         && prop !== 'onMomentumScrollEnd'
         && prop !== 'renderPagination'
         && prop !== 'onScrollBeginDrag'
+        && prop !== 'renderLeftLoopView'
+        && prop !== 'renderRightLoopView'
       ) {
         let originResponder = props[prop]
         props[prop] = (e) => originResponder(e, this.state, this)
@@ -496,14 +500,20 @@ module.exports = React.createClass({
 
       // Re-design a loop model for avoid img flickering
       pages = Object.keys(children)
-      if(loop) {
+      const loopBoundaryViewsIncluded = this.props.renderLeftLoopView && this.props.renderRightLoopView;
+      if(loop && !loopBoundaryViewsIncluded) {
         pages.unshift(total - 1)
         pages.push(0)
       }
 
       pages = pages.map((page, i) =>
-        <View style={pageStyle} key={i}>{children[page]}</View>
+        <View style={pageStyle} key={i + (loopBoundaryViewsIncluded || 0)}>{children[page]}</View>
       )
+
+      if (loopBoundaryViewsIncluded) {
+        pages.unshift(<View style={pageStyle} key={0}>{this.props.renderLeftLoopView()}</View>);
+        pages.push(<View style={pageStyle} key={total + 1}>{this.props.renderRightLoopView()}</View>);
+      }
     }
     else pages = <View style={pageStyle}>{children}</View>
 


### PR DESCRIPTION
This commit adds ability to specify custom views used in loop mode at the boundaries of the loop - instead of duplicating existing first and last view.

Additionally, I fixed the support for _index_ prop in loop mode.

**Situation before**
Before using swiper in "loop" mode with any more complex views was problematic, especially if the views required doing some initialization steps on loading, such as fetching latest messages (the views got duplicated automatically and fetching was called twice). The same problem appeared if the view listened to some events - when event occurred, this triggered actions on all the cloned views and thus the event got handled twice.

**TODO:**
[] renderLeftLoopView and renderRightLoopView should be added to documentation
[] would be nice to create examples of this usage
