### PR TITLE
Fix for #95

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,7 +318,7 @@ module.exports = React.createClass({
     let y = 0
     if(state.dir == 'x') x = diff * state.width
     if(state.dir == 'y') y = diff * state.height
-    this.refs.scrollView && this.refs.scrollView.scrollTo(y, x)
+    this.refs.scrollView && this.refs.scrollView.scrollTo({x: x,y: y,animated: true})
 
     // update scroll state
     this.setState({


### PR DESCRIPTION
The below message comes when swiper's props 'index' is not zero.
"scrollTo(y, x, animated) is deprecated. Use scrollTo({x: 5, y: 5, animated: true}) instead."