### PR TITLE
fix for #97

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -197,7 +197,10 @@ module.exports = _reactNative2.default.createClass({
     initState.offset = {};
 
     if (initState.total > 1) {
-      var setup = props.loop ? 1 : initState.index;
+      var setup = initState.index;
+      if (props.loop) {
+        setup++;
+      }
       initState.offset[initState.dir] = initState.dir == 'y' ? initState.height * setup : initState.width * setup;
     }
     return initState;

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,10 @@ module.exports = React.createClass({
     initState.offset = {}
 
     if (initState.total > 1) {
-      var setup = props.loop ? 1 : initState.index
+      var setup = initState.index
+      if ( props.loop ) {
+        setup++
+      }
       initState.offset[initState.dir] = initState.dir == 'y'
         ? initState.height * setup
         : initState.width * setup


### PR DESCRIPTION
As noted in #82 the index prop can be used to maintain the index on state change. (Otherwise, a re-render resets the swiper to the initial position.) However, I noticed that this solution only works for me when loop={false}. The problem when loop={true} is the position of the swiper resets to the first child element.

Upon closer inspection, the index on the internal context is what it should be. The problems looks to be in the initState method the setup variable is always set to 1 when props.loop is true ( `var setup = props.loop ? 1 : initState.index;`).

I believe changing that line to the following will fix the issue.
```
      var setup = initState.index
      if ( props.loop ) {
        setup++
      }
```