### PR TITLE
Updates depricated scrollView.scrollTo(x,y)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,7 +318,7 @@ module.exports = React.createClass({
     let y = 0
     if(state.dir == 'x') x = diff * state.width
     if(state.dir == 'y') y = diff * state.height
-    this.refs.scrollView && this.refs.scrollView.scrollTo(y, x)
+    this.refs.scrollView && this.refs.scrollView.scrollTo({y:y, x:x})
 
     // update scroll state
     this.setState({


### PR DESCRIPTION
Current implementation gives a warning regarding deprecation of scrollTo(x,y) and recommends using an object as an options hash scrollTo({x:x,y:y})

Pull request fixes the only instance of the native scrollTo method invocation with scrollTo({y:y,x:x}) and eliminates the warning.

Tested by editing the instance of the component in my project dist folder, building to my iPhone, and verifying that the warning no longer appears.