### PR TITLE
解决scrollTo的参数scrollTo({y, x})deprecated的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "version": "1.4.3",
   "description": "Swiper component for React Native.",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "scripts": {
     "start": "babel src --out-dir dist --presets es2015,react",
     "watch": "babel src --out-dir dist --watch --presets es2015,react"

--- a/src/index.js
+++ b/src/index.js
@@ -318,7 +318,7 @@ module.exports = React.createClass({
     let y = 0
     if(state.dir == 'x') x = diff * state.width
     if(state.dir == 'y') y = diff * state.height
-    this.refs.scrollView && this.refs.scrollView.scrollTo(y, x)
+    this.refs.scrollView && this.refs.scrollView.scrollTo({y:y, x:x})
 
     // update scroll state
     this.setState({


### PR DESCRIPTION
scrollTo({y, x})已经成为的deprecated的API,已改为scrollTo({y:y, x:x})。
同时，es6的语法，现在已经普遍开始采用，已将package.json的main入口改为src/index.js。