### PR TITLE
Fix scrollTo deprecation warnings

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -318,7 +318,13 @@ module.exports = _reactNative2.default.createClass({
     var y = 0;
     if (state.dir == 'x') x = diff * state.width;
     if (state.dir == 'y') y = diff * state.height;
-    this.refs.scrollView && this.refs.scrollView.scrollTo(y, x);
+    if (this.refs.scrollView) {
+      if (_reactNative.Platform.OS === 'ios') {
+        this.refs.scrollView.scrollTo({ y: y, x: x });
+      } else {
+        this.refs.scrollView.setPage(index);
+      }
+    }
 
     // update scroll state
     this.setState({

--- a/dist/index.js
+++ b/dist/index.js
@@ -311,6 +311,8 @@ module.exports = _reactNative2.default.createClass({
    * @param  {number} index offset index
    */
   scrollTo: function scrollTo(index) {
+    var animated = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+
     if (this.state.isScrolling || this.state.total < 2) return;
     var state = this.state;
     var diff = (this.props.loop ? 1 : 0) + index + this.state.index;
@@ -320,9 +322,9 @@ module.exports = _reactNative2.default.createClass({
     if (state.dir == 'y') y = diff * state.height;
     if (this.refs.scrollView) {
       if (_reactNative.Platform.OS === 'ios') {
-        this.refs.scrollView.scrollTo({ y: y, x: x });
+        this.refs.scrollView.scrollTo({ y: y, x: x, animated: animated });
       } else {
-        this.refs.scrollView.setPage(index);
+        animated ? this.refs.scrollView.setPage(index) : this.refs.scrollView.setPageWithoutAnimation(index);
       }
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -321,10 +321,13 @@ module.exports = _reactNative2.default.createClass({
     if (state.dir == 'x') x = diff * state.width;
     if (state.dir == 'y') y = diff * state.height;
     if (this.refs.scrollView) {
-      if (_reactNative.Platform.OS === 'ios') {
-        this.refs.scrollView.scrollTo({ y: y, x: x, animated: animated });
-      } else {
-        animated ? this.refs.scrollView.setPage(index) : this.refs.scrollView.setPageWithoutAnimation(index);
+      switch (_reactNative.Platform.OS) {
+        case 'ios':
+          this.refs.scrollView.scrollTo({ y: y, x: x, animated: animated });
+          break;
+        case 'android':
+          animated ? this.refs.scrollView.setPage(index) : this.refs.scrollView.setPageWithoutAnimation(index);
+          break;
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -310,7 +310,7 @@ module.exports = React.createClass({
    * Scroll by index
    * @param  {number} index offset index
    */
-  scrollTo(index) {
+  scrollTo(index, animated = true) {
     if (this.state.isScrolling || this.state.total < 2) return
     let state = this.state
     let diff = (this.props.loop ? 1 : 0) + index + this.state.index
@@ -320,9 +320,11 @@ module.exports = React.createClass({
     if(state.dir == 'y') y = diff * state.height
     if (this.refs.scrollView) {
       if (Platform.OS === 'ios') {
-        this.refs.scrollView.scrollTo({y, x})
+        this.refs.scrollView.scrollTo({y, x, animated})
       } else {
-        this.refs.scrollView.setPage(index)
+        animated ?
+          this.refs.scrollView.setPage(index) :
+          this.refs.scrollView.setPageWithoutAnimation(index)
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -318,7 +318,13 @@ module.exports = React.createClass({
     let y = 0
     if(state.dir == 'x') x = diff * state.width
     if(state.dir == 'y') y = diff * state.height
-    this.refs.scrollView && this.refs.scrollView.scrollTo(y, x)
+    if (this.refs.scrollView) {
+      if (Platform.OS === 'ios') {
+        this.refs.scrollView.scrollTo({y, x})
+      } else {
+        this.refs.scrollView.setPage(index)
+      }
+    }
 
     // update scroll state
     this.setState({

--- a/src/index.js
+++ b/src/index.js
@@ -319,12 +319,15 @@ module.exports = React.createClass({
     if(state.dir == 'x') x = diff * state.width
     if(state.dir == 'y') y = diff * state.height
     if (this.refs.scrollView) {
-      if (Platform.OS === 'ios') {
-        this.refs.scrollView.scrollTo({y, x, animated})
-      } else {
-        animated ?
-          this.refs.scrollView.setPage(index) :
-          this.refs.scrollView.setPageWithoutAnimation(index)
+      switch (Platform.OS) {
+        case 'ios':
+          this.refs.scrollView.scrollTo({y, x, animated})
+          break
+        case 'android':
+          animated ?
+            this.refs.scrollView.setPage(index) :
+            this.refs.scrollView.setPageWithoutAnimation(index)
+          break
       }
     }
 


### PR DESCRIPTION
This fixes #118, #106 and #95 by also considering the usage of `ViewPager` on Android.