### PR TITLE
Fixes issue #12:  Allow a prop to update to a new active index

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -201,7 +201,7 @@ module.exports = _react2.default.createClass({
 
     initState.total = props.children ? props.children.length || 1 : 0;
 
-    if (state.total === initState.total) {
+    if (state.total === initState.total && props.index === this.props.index) {
       // retain the index
       initState.index = state.index;
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,7 @@ module.exports = React.createClass({
 
     initState.total = props.children ? props.children.length || 1 : 0
 
-    if (state.total === initState.total) {
+    if (state.total === initState.total && props.index === this.props.index) {
       // retain the index
       initState.index = state.index
     } else {


### PR DESCRIPTION
This change will allow a parent component to correctly update the `Swiper`'s `index` prop and have it reflected in the state, and hence the rendering of the correct slide.  I only focused on displaying the correct slide and did not focus on whether or not it animates correctly.