### PR TITLE
fix float calculation  error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -338,7 +338,7 @@ module.exports = _react2.default.createClass({
     // Note: if touch very very quickly and continuous,
     // the variation of `index` more than 1.
     // parseInt() ensures it's always an integer
-    index = parseInt(index + diff / step);
+    index = parseInt(index + Math.round(diff / step));
 
     if (this.props.loop) {
       if (index <= -1) {

--- a/src/index.js
+++ b/src/index.js
@@ -296,7 +296,7 @@ module.exports = React.createClass({
     let { offset, index } = this.state
     let previousOffset = horizontal ? offset.x : offset.y
     let newOffset = horizontal ? contentOffset.x : contentOffset.y
-    
+
     if (previousOffset === newOffset && (index === 0 || index === children.length - 1)) {
       this.setState({
         isScrolling: false
@@ -322,7 +322,7 @@ module.exports = React.createClass({
     // Note: if touch very very quickly and continuous,
     // the variation of `index` more than 1.
     // parseInt() ensures it's always an integer
-    index = parseInt(index + diff / step)
+    index = parseInt(index + Math.round(diff / step))
 
     if(this.props.loop) {
       if(index <= -1) {


### PR DESCRIPTION
because `Dimensions.get('window').width` return a float number.
so when diff and step is float, especially on some Android devices, sometimes `parseInt` will not change index which should be correctly +1.

example:
```javascript
// test on Google Nexus 5X
const index = 0
const diff = 1237.2835597264346
const step = 412.427853242145 
// because (diff / step) will return 2.99999999999
parseInt(index + diff / step) //  will return 2 but expected to return 3
```
so I add `Math.round` try to solve this.
use `parseInt(index + Math.round(diff / step))` or  `Math.round(index + diff / step)` 