### PR TITLE
Added extra check for title

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -469,7 +469,7 @@ module.exports = React.createClass({
 
   renderTitle() {
     let child = this.props.children[this.state.index]
-    let title = child && child.props.title
+    let title = child && child.props && child.props.title
     return title
       ? (
         <View style={styles.title}>


### PR DESCRIPTION
Just a small addition!

Simply turned
`let title = child && child.props.title`
to
`let title = child && child.props && child.props.title`

Because my app crashed when child.props turned out to be undefined.