### PR TITLE
changed a small typo in comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -432,7 +432,7 @@ module.exports = React.createClass({
    */
   renderPagination() {
 
-    // By default, dots only show when `total` > 2
+    // By default, dots only show when `total` >= 2
     if(this.state.total <= 1) return null
 
     let dots = []


### PR DESCRIPTION
There was a small typo in comments which said, the pagination will only be rendered if the 'total' was greater than 2, where it should have been greater than 1. 