### PR TITLE
Fix jitter when quickly swiping back and forth between pages (iOS)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,10 +168,6 @@ export default class extends Component {
     this.autoplay()
   }
 
-  shouldComponentUpdate () {
-    return !this.internals.isScrolling
-  }
-
   componentWillUnmount () {
     this.autoplayTimer && clearTimeout(this.autoplayTimer)
     this.loopJumpTimer && clearTimeout(this.loopJumpTimer)

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,7 @@ export default class extends Component {
       initState.index = state.index
     } else {
       // reset the index
+      setOffsetInState = true // if the index is reset, go ahead and update the offset in state
       initState.index = initState.total > 1 ? Math.min(props.index, initState.total - 1) : 0
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -293,7 +293,7 @@ export default class extends Component {
       this.loopJump()
 
       // if `onMomentumScrollEnd` registered will be called here
-      this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e, this.state, this)
+      this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e, this.fullState(), this)
     })
   }
 
@@ -413,7 +413,7 @@ export default class extends Component {
         prop !== 'onScrollBeginDrag'
       ) {
         let originResponder = props[prop]
-        overrides[prop] = (e) => originResponder(e, this.state, this)
+        overrides[prop] = (e) => originResponder(e, this.fullState(), this)
       }
     }
 


### PR DESCRIPTION
The problem: After a swipe is complete and the offset is being set in the state, if you keep swiping you can potentially have the ScrollView's internal offset be different than the one you are setting in state. If this is the case, then when the render happens and the offset is passed in as a prop to ScrollView, then it resets the offset to the one specified. The result is that you can be mid-swipe and the pages will jump back partially to the old offset causing some nasty jitter.

The fix: I added this.internals to store calculated values that are used a lot and are passed back to callbacks, but do not directly effect the render (isScrolling and offset). Offset does effect rendering but should only effect it when the size changes or if total pages changes. So offset is stored in this.internals most of the time and it's occasionally saved to the state to force the ScrollView to update. You will notice the callbacks that were getting this.state passed to them now get this.fullState() which includes state and internals.
