### PR TITLE
Fix jitter when quickly swiping back and forth between pages (iOS)

### DIFF
--- a/examples/components/SwiperNumber/index.js
+++ b/examples/components/SwiperNumber/index.js
@@ -34,10 +34,10 @@ const renderPagination = (index, total, context) => {
   return (
     <View style={{
       position: 'absolute',
-      bottom: 10
+      bottom: 10,
       right: 10
     }}>
-      <Text style={{ color:'grey' }}>
+      <Text style={{ color: 'grey' }}>
         <Text style={{
           color: 'white',
           fontSize: 20

--- a/src/index.js
+++ b/src/index.js
@@ -363,13 +363,11 @@ export default class extends Component {
         this.setState(newState, () => {
           this.setState({ offset: offset }, cb)
         })
-      }
-      else {
+      } else {
         newState.offset = offset
         this.setState(newState, cb)
       }
-    }
-    else {
+    } else {
       this.setState(newState, cb)
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ export default class extends Component {
    * Init states
    * @return {object} states
    */
-  state = this.initState(this.props)
+  state = this.initState(this.props, true)
 
   /**
    * autoplay timer
@@ -158,8 +158,10 @@ export default class extends Component {
   autoplayTimer = null
   loopJumpTimer = null
 
-  componentWillReceiveProps (props) {
-    this.setState(this.initState(props))
+  componentWillReceiveProps (nextProps) {
+    const sizeChanged = (nextProps.width || width) !== this.state.width ||
+                        (nextProps.height || height) !== this.state.height
+    this.setState(this.initState(nextProps, sizeChanged))
   }
 
   componentDidMount () {
@@ -171,14 +173,17 @@ export default class extends Component {
     this.loopJumpTimer && clearTimeout(this.loopJumpTimer)
   }
 
-  initState (props) {
+  initState (props, setOffsetInState) {
     // set the current state
     const state = this.state || {}
 
-    let initState = {
-      isScrolling: false,
+    const initState = {
       autoplayEnd: false,
       loopJump: false
+    }
+
+    const newInternals = {
+      isScrolling: false
     }
 
     initState.total = props.children ? props.children.length || 1 : 0
@@ -188,6 +193,7 @@ export default class extends Component {
       initState.index = state.index
     } else {
       // reset the index
+      setOffsetInState = true // if the index is reset, go ahead and update the offset in state
       initState.index = initState.total > 1 ? Math.min(props.index, initState.total - 1) : 0
     }
 
@@ -195,18 +201,31 @@ export default class extends Component {
     initState.dir = props.horizontal === false ? 'y' : 'x'
     initState.width = props.width || width
     initState.height = props.height || height
-    initState.offset = {}
+    newInternals.offset = {}
 
     if (initState.total > 1) {
       let setup = initState.index
       if (props.loop) {
         setup++
       }
-      initState.offset[initState.dir] = initState.dir === 'y'
+      newInternals.offset[initState.dir] = initState.dir === 'y'
         ? initState.height * setup
         : initState.width * setup
     }
+
+    // only update the offset in state if needed, updating offset while swiping
+    // causes some bad jumping / stuttering
+    if (setOffsetInState) {
+      initState.offset = newInternals.offset
+    }
+
+    this.internals = newInternals
     return initState
+  }
+
+  // include internals with state
+  fullState () {
+    return Object.assign({}, this.state, this.internals)
   }
 
   loopJump = () => {
@@ -223,7 +242,7 @@ export default class extends Component {
   autoplay = () => {
     if (!Array.isArray(this.props.children) ||
       !this.props.autoplay ||
-      this.state.isScrolling ||
+      this.internals.isScrolling ||
       this.state.autoplayEnd) return
 
     this.autoplayTimer && clearTimeout(this.autoplayTimer)
@@ -245,9 +264,8 @@ export default class extends Component {
    */
   onScrollBegin = e => {
     // update scroll state
-    this.setState({ isScrolling: true }, () => {
-      this.props.onScrollBeginDrag && this.props.onScrollBeginDrag(e, this.state, this)
-    })
+    this.internals.isScrolling = true
+    this.props.onScrollBeginDrag && this.props.onScrollBeginDrag(e, this.fullState(), this)
   }
 
   /**
@@ -256,9 +274,7 @@ export default class extends Component {
    */
   onScrollEnd = e => {
     // update scroll state
-    this.setState({
-      isScrolling: false
-    })
+    this.internals.isScrolling = false
 
     // making our events coming from android compatible to updateIndex logic
     if (!e.nativeEvent.contentOffset) {
@@ -274,7 +290,7 @@ export default class extends Component {
       this.loopJump()
 
       // if `onMomentumScrollEnd` registered will be called here
-      this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e, this.state, this)
+      this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e, this.fullState(), this)
     })
   }
 
@@ -285,15 +301,14 @@ export default class extends Component {
   onScrollEndDrag = e => {
     const { contentOffset } = e.nativeEvent
     const { horizontal, children } = this.props
-    const { offset, index } = this.state
+    const { index } = this.state
+    const { offset } = this.internals
     const previousOffset = horizontal ? offset.x : offset.y
     const newOffset = horizontal ? contentOffset.x : contentOffset.y
 
     if (previousOffset === newOffset &&
       (index === 0 || index === children.length - 1)) {
-      this.setState({
-        isScrolling: false
-      })
+      this.internals.isScrolling = false
     }
   }
 
@@ -305,7 +320,7 @@ export default class extends Component {
   updateIndex = (offset, dir, cb) => {
     const state = this.state
     let index = state.index
-    const diff = offset[dir] - state.offset[dir]
+    const diff = offset[dir] - this.internals.offset[dir]
     const step = dir === 'x' ? state.width : state.height
     let loopJump = false
 
@@ -329,9 +344,9 @@ export default class extends Component {
       }
     }
 
+    this.internals.offset = offset
     this.setState({
       index: index,
-      offset: offset,
       loopJump: loopJump
     }, cb)
   }
@@ -343,7 +358,7 @@ export default class extends Component {
    */
 
   scrollBy = (index, animated = true) => {
-    if (this.state.isScrolling || this.state.total < 2) return
+    if (this.internals.isScrolling || this.state.total < 2) return
     const state = this.state
     const diff = (this.props.loop ? 1 : 0) + index + this.state.index
     let x = 0
@@ -358,8 +373,8 @@ export default class extends Component {
     }
 
     // update scroll state
+    this.internals.isScrolling = true
     this.setState({
-      isScrolling: true,
       autoplayEnd: false
     })
 
@@ -397,7 +412,7 @@ export default class extends Component {
         prop !== 'onScrollBeginDrag'
       ) {
         let originResponder = props[prop]
-        overrides[prop] = (e) => originResponder(e, this.state, this)
+        overrides[prop] = (e) => originResponder(e, this.fullState(), this)
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -344,11 +344,34 @@ export default class extends Component {
       }
     }
 
+    const newState = {}
+    newState.index = index
+    newState.loopJump = loopJump
+
     this.internals.offset = offset
-    this.setState({
-      index: index,
-      loopJump: loopJump
-    }, cb)
+
+    // only update offset in state if loopJump is true
+    if (loopJump) {
+      // when swiping to the beginning of a looping set for the third time,
+      // the new offset will be the same as the last one set in state.
+      // Setting the offset to the same thing will not do anything,
+      // so we increment it by 1 then immediately set it to what it should be,
+      // after render.
+      if (offset[dir] === this.state.offset[dir]) {
+        newState.offset = { x: 0, y: 0 }
+        newState.offset[dir] = offset[dir] + 1
+        this.setState(newState, () => {
+          this.setState({ offset: offset }, cb)
+        })
+      }
+      else {
+        newState.offset = offset
+        this.setState(newState, cb)
+      }
+    }
+    else {
+      this.setState(newState, cb)
+    }
   }
 
   /**


### PR DESCRIPTION
The problem: After a swipe is complete and the offset is being set in the state, if you keep swiping you can potentially have the ScrollView's internal offset be different than the one you are setting in state. If this is the case, then when the render happens and the offset is passed in as a prop to ScrollView, then it resets the offset to the one specified. The result is that you can be mid-swipe and the pages will jump back partially to the old offset causing some nasty jitter.

The fix: I added this.internals to store calculated values that are used a lot and are passed back to callbacks, but do not directly effect the render (isScrolling and offset). Offset does effect rendering but should only effect it when the size changes or if total pages changes. So offset is stored in this.internals most of the time and it's occasionally saved to the state to force the ScrollView to update. You will notice the callbacks that were getting this.state passed to them now get this.fullState() which includes state and internals.

Also includes some extra linting.