### PR TITLE
Fix case where going from 1 child to several causes the 1st view to b…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -575,7 +575,7 @@ export default class extends Component {
         }
       })
     } else {
-      pages = <View style={pageStyle}>{children}</View>
+      pages = <View style={pageStyle} key={0}>{children}</View>
     }
 
     return (


### PR DESCRIPTION
…e destroyed due to diffing key.

We discovered this when loading a single webview and then populating the swiper with more items later. The first webview always reloaded when injecting the rest of the children.