### PR TITLE
Allow dotStyle and activeDotStyle PropTypes to accept StyleSheet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,8 @@ export default class extends Component {
     autoplayDirection: PropTypes.bool,
     index: PropTypes.number,
     renderPagination: PropTypes.func,
-    dotStyle: PropTypes.object,
-    activeDotStyle: PropTypes.object,
+    dotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+    activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     dotColor: PropTypes.string,
     activeDotColor: PropTypes.string
   }


### PR DESCRIPTION
As mentioned in [RN Docs](https://facebook.github.io/react-native/docs/stylesheet.html) `StyleSheet` are passed not as objects, but as numbers (references), due to performance reasons.
This change would disable annoying `PropTypes` warnings when `StyleSheet` is passed to `dotStyle` and `activeDotStyle`.