### PR TITLE
Changed export to use es6 syntax instead of commonjs. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 import Swiper from './src/'
-module.exports = Swiper
+export default Swiper;


### PR DESCRIPTION
For some(unknown, might be something in TS config) reason typescript is not happy with commonjs export.I have not investigated the reason since I am satisfied using ES6 exports instead.


My tsconfig.json:
``` 
{
    "compilerOptions": {
        "allowJs": true,
        "target": "es6",
        "outDir": "build",
        "jsx": "react",
        "module": "commonjs",
        "pretty": true,
        "noUnusedParameters" : true,
        "noUnusedLocals" : true,
        "experimentalDecorators": true
    },
    "include": [
        "src/**/*"
    ]
}
```



Since ES6 import is already used, nothing should break by using ES6 export also.