### PR TITLE
Update from View.propTypes to ViewPropTypes to match RN v0.44.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ import {
   TouchableOpacity,
   ViewPagerAndroid,
   Platform,
-  ActivityIndicator
+  ActivityIndicator,
+  ViewPropTypes
 } from 'react-native'
 
 const { width, height } = Dimensions.get('window')
@@ -100,7 +101,7 @@ export default class extends Component {
   static propTypes = {
     horizontal: PropTypes.bool,
     children: PropTypes.node.isRequired,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     pagingEnabled: PropTypes.bool,
     showsHorizontalScrollIndicator: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,


### PR DESCRIPTION
Update the ViewPropTypes to match the last revision of React Native V0.44.0

> View.propTypes to ViewPropTypes (53905a5) - @bvaughn

https://github.com/facebook/react-native/releases