### PR TITLE
It is now possible to listen to index changes when user swipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | index | 0 | `number` | Index number of initial slide. |
 | showsButtons | false | `bool` | Set to `true` make control buttons visible. |
 | autoplay | false | `bool` | Set to `true` enable auto play mode. |
+| onIndexChanged | (index) => null | `func` | Called with the new index when the user swiped |
 
 #### Custom basic style & content
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,11 @@ export default class extends Component {
     dotStyle: PropTypes.object,
     activeDotStyle: PropTypes.object,
     dotColor: PropTypes.string,
-    activeDotColor: PropTypes.string
+    activeDotColor: PropTypes.string,
+    /**
+     * Called when the index has changed because the user swiped.
+     */
+    onIndexChanged: PropTypes.func
   }
 
   /**
@@ -147,7 +151,8 @@ export default class extends Component {
     autoplay: false,
     autoplayTimeout: 2.5,
     autoplayDirection: true,
-    index: 0
+    index: 0,
+    onIndexChanged: () => null
   }
 
   /**
@@ -349,6 +354,9 @@ export default class extends Component {
         loopJump = true
       }
     }
+
+    // Notify that the index has changed
+    this.props.onIndexChanged(index)
 
     const newState = {}
     newState.index = index

--- a/src/index.js
+++ b/src/index.js
@@ -184,6 +184,11 @@ export default class extends Component {
     this.loopJumpTimer && clearTimeout(this.loopJumpTimer)
   }
 
+  componentWillUpdate (nextProps, nextState) {
+    // If the index has changed, we notify the parent via the onIndexChanged callback
+    if (this.state.index !== nextState.index) this.props.onIndexChanged(nextState.index)
+  }
+
   initState (props, setOffsetInState) {
     // set the current state
     const state = this.state || {}
@@ -354,9 +359,6 @@ export default class extends Component {
         loopJump = true
       }
     }
-
-    // Notify that the index has changed
-    this.props.onIndexChanged(index)
 
     const newState = {}
     newState.index = index


### PR DESCRIPTION
There is now a simple way to listen to user's swipes.

I added a method `onIndexChanged` that is called with the new index everytime the user swipes. This allows, for example, to link this component to a Redux store.

Fixes #436 