### PR TITLE
preventing apps using previous version to crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,8 @@ export default class extends Component {
   static propTypes = {
     horizontal: PropTypes.bool,
     children: PropTypes.node.isRequired,
-    containerStyle: ViewPropTypes.style,
-    style: ViewPropTypes.style,
+    containerStyle: PropTypes.any,
+    style: PropTypes.any,
     pagingEnabled: PropTypes.bool,
     showsHorizontalScrollIndicator: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,14 @@ export default class extends Component {
   static propTypes = {
     horizontal: PropTypes.bool,
     children: PropTypes.node.isRequired,
-    containerStyle: PropTypes.any,
-    style: PropTypes.any,
+    containerStyle: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.number,
+    ]),
+    style: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.number,
+    ]),
     pagingEnabled: PropTypes.bool,
     showsHorizontalScrollIndicator: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,


### PR DESCRIPTION
Prevent this crash : 
```
com.facebook.react.bridge.UnexpectedNativeTypeException: TypeError: expected dynamic type `int64', but had type `null'
        at com.facebook.react.bridge.ReadableNativeMap.getInt(Native Method)
```

when using one of the latest release.