### PR TITLE
Fix iOS initial index issue && Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "react-native-swiper",
-  "keywords": ["react-component", "react-native", "ios"],
-  "version": "1.5.9",
+  "keywords": [
+    "react-component",
+    "react-native",
+    "ios"
+  ],
+  "version": "1.5.10",
   "description": "Swiper component for React Native.",
   "main": "index.js",
   "scripts": {
@@ -12,7 +16,9 @@
     "test": "npm run lint"
   },
   "pre-commit": {
-    "run": ["precommit"],
+    "run": [
+      "precommit"
+    ],
     "silent": true
   },
   "standard": {
@@ -25,7 +31,11 @@
       "setImmediate",
       "fetch"
     ],
-    "ignore": ["dist/", "mock/", "node_modules/"]
+    "ignore": [
+      "dist/",
+      "mock/",
+      "node_modules/"
+    ]
   },
   "ava": {
     "babel": "inherit",

--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ export default class extends Component {
 
     // only update the offset in state if needed, updating offset while swiping
     // causes some bad jumping / stuttering
-    if (width !== this.state.width || height !== this.state.height) {
+    if (!this.state.offset || width !== this.state.width || height !== this.state.height) {
       state.offset = offset
     }
     this.setState(state)


### PR DESCRIPTION
### Version

- react-native-swiper v1.5.9
- react-native v0.44.3

### Expected behaviour

Index page is displayed after render

### Actual behaviour

First item is displayed, with paging showing correct dot highlighted.

### Steps to reproduce
For non-obvious bugs, please fork this component, modify Example project to reproduce your issue and include link here.
1. Create swiper that takes full width of page
2. Set non-zero index
3. Observe first page (with zero index) rendered as initial.
