### PR TITLE
Fix 'index' prop on iOS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,6 +239,7 @@ export default class extends Component {
 
   onLayout = (event) => {
     const { width, height } = event.nativeEvent.layout
+    const firstLayout = typeof this.internals.offset === 'undefined'
     const offset = this.internals.offset = {}
     const state = { width, height }
 
@@ -254,7 +255,7 @@ export default class extends Component {
 
     // only update the offset in state if needed, updating offset while swiping
     // causes some bad jumping / stuttering
-    if (width !== this.state.width || height !== this.state.height) {
+    if (firstLayout || (width !== this.state.width || height !== this.state.height)) {
       state.offset = offset
     }
     this.setState(state)


### PR DESCRIPTION
### Is it a bugfix ?

Yes, commit ff12771 breaks the `index` prop on `iOS` which means you can't set the first slide anymore.

### Is it a new feature ?

Nope

### Describe what you've done:

The condition on line `258` is always `false`, `this.state.offset` wasn't set on the first render.

### How to test it ?

Render the swiper with an `index` set to an int, you can see it starts properly on this value.