### PR TITLE
update index when new index passed through props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ export default class extends Component {
 
   componentWillReceiveProps (nextProps) {
     if (!nextProps.autoplay && this.autoplayTimer) clearTimeout(this.autoplayTimer)
-    this.setState(this.initState(nextProps))
+    this.setState(this.initState(nextProps, this.props.index !== nextProps.index))
   }
 
   componentDidMount () {
@@ -202,7 +202,7 @@ export default class extends Component {
     if (this.state.index !== nextState.index) this.props.onIndexChanged(nextState.index)
   }
 
-  initState (props) {
+  initState (props, updateIndex = false) {
     // set the current state
     const state = this.state || { width: 0, height: 0, offset: { x: 0, y: 0 } }
 
@@ -213,7 +213,7 @@ export default class extends Component {
 
     initState.total = props.children ? props.children.length || 1 : 0
 
-    if (state.total === initState.total) {
+    if (state.total === initState.total && !updateIndex) {
       // retain the index
       initState.index = state.index
     } else {


### PR DESCRIPTION
Hello!

### Is it a bugfix ?
No

### Is it a new feature ?
Yes

### Describe what you've done:

When I tap Dot in my Custom Pagination I need somehow to update index in Swiper. To show currently active Dot

### How to test it ?

Update index in Swiper component. It should return correct new index