### PR TITLE
Calculate the offset in the initial state instead of `onLayout`.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,8 @@ export default class extends Component {
 
     const initState = {
       autoplayEnd: false,
-      loopJump: false
+      loopJump: false,
+      offset: {}
     }
 
     initState.total = props.children ? props.children.length || 1 : 0
@@ -224,6 +225,9 @@ export default class extends Component {
     initState.dir = props.horizontal === false ? 'y' : 'x'
     initState.width = props.width || width
     initState.height = props.height || height
+    initState.offset[initState.dir] = initState.dir === 'y'
+      ? height * props.index
+      : width * props.index
 
     this.internals = {
       ...this.internals,


### PR DESCRIPTION
Enables the inital index to be rendered first, avoiding a render of uncalculated offset.

### Is it a bugfix ?
- Yes
- [#540](https://github.com/leecade/react-native-swiper/issues/540) ?

### Is it a new feature ?
- No

### Describe what you've done:
Calculate the offset of the index prop in the initial state.
Enables the initial index to be rendered first, avoiding a render of uncalculated offset.

### How to test it ?
Provide index prop >0.
