### PR TITLE
Import ViewStyle from react-native module instead of React

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,9 @@
+import { ViewStyle } from 'react-native';
+import * as React from "react";
+
 declare module "react-native-swiper" {
     export interface SwiperProps {
-        style?: React.ViewStyle;
+        style?: ViewStyle;
         showsButtons?: boolean;
         horizontal?: boolean;
         pagingEnabled?: boolean;
@@ -20,9 +23,9 @@ declare module "react-native-swiper" {
         autoplayDirection?: boolean;
         index?: number;
         renderPagination?: (index: number, total: number, swiper: Swiper) => JSX.Element;
-        dotStyle?: React.ViewStyle;
-        activeDotStyle?: React.ViewStyle;
-        paginationStyle?: React.ViewStyle;
+        dotStyle?: ViewStyle;
+        activeDotStyle?: ViewStyle;
+        paginationStyle?: ViewStyle;
         dotColor?: string;
         activeDotColor?: string;
     }


### PR DESCRIPTION
### Is it a bugfix?
Yes, issue #542.

### Is it a new feature?
No

### Describe what you've done:
Import `ViewStyle` in index.d.ts file from `react-native` module instead of a `React`. This fixes an issue with project compilation.

### How to test it ?
Compile project with the command: `tsc`.