### PR TITLE
Calculated width & height on layout, used later on re-rendering. Possibility to change ScrollView styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -222,8 +222,21 @@ export default class extends Component {
 
     // Default: horizontal
     initState.dir = props.horizontal === false ? 'y' : 'x'
-    initState.width = props.width || width
-    initState.height = props.height || height
+    if (props.width) {
+      initState.width = props.width
+    } else if (this.state && this.state.width){
+      initState.width = this.state.width
+    } else {
+      initState.width = width;
+    }
+
+    if (props.height) {
+      initState.height = props.height
+    } else if (this.state && this.state.height){
+      initState.height = this.state.height
+    } else {
+      initState.height = height;
+    }
 
     this.internals = {
       ...this.internals,

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,10 @@ export default class extends Component {
       PropTypes.object,
       PropTypes.number,
     ]),
+    scrollViewStyle: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.number,
+    ]),
     pagingEnabled: PropTypes.bool,
     showsHorizontalScrollIndicator: PropTypes.bool,
     showsVerticalScrollIndicator: PropTypes.bool,
@@ -593,7 +597,8 @@ export default class extends Component {
           contentOffset={this.state.offset}
           onScrollBeginDrag={this.onScrollBegin}
           onMomentumScrollEnd={this.onScrollEnd}
-          onScrollEndDrag={this.onScrollEndDrag}>
+          onScrollEndDrag={this.onScrollEndDrag}
+          style={this.props.scrollViewStyle}>
           {pages}
         </ScrollView>
        )


### PR DESCRIPTION
When swiper component is mounted, width and height are calculated and set in state. But if you change to another view in your app (in my case pressing on another tab, I'm using tabs from 'react-native-scrollable-tab-view'), the component is not unmounted, so if you come back to the view which contents swiper component, it is doing this:
`
initState.width = props.width || width // same with height
`
and it's not correct, because it should set previously calculated width and height, which is stored in state.
In my case, calculated height was 465 (correct, calculated by onLayout function), but when I came back height was set to 500 (incorrect, given by `const { width, height } = Dimensions.get('window')`)

I also needed to set style prop to ScrollView, so I added it.
