### PR TITLE
Workaround for react-native 0.4.8 contentOffset regression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ export default class extends Component {
     // contentOffset is not working in react 0.48.x so we need to use scrollTo
     // to emulate offset.
     if (Platform.OS === 'ios') {
-      if (this.initialRender && this.props.loop && this.state.total > 1) {
+      if (this.initialRender && this.state.total > 1) {
         this.scrollView.scrollTo({...offset, animated: false})
         this.initialRender = false;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,12 @@ export default class extends Component {
   state = this.initState(this.props)
 
   /**
+   * Initial render flag
+   * @type {bool}
+   */
+  initialRender = true
+
+  /**
    * autoplay timer
    * @type {null}
    */
@@ -263,6 +269,17 @@ export default class extends Component {
     if (!this.state.offset || width !== this.state.width || height !== this.state.height) {
       state.offset = offset
     }
+
+    // related to https://github.com/leecade/react-native-swiper/issues/570
+    // contentOffset is not working in react 0.48.x so we need to use scrollTo
+    // to emulate offset.
+    if (Platform.OS === 'ios') {
+      if (this.initialRender && this.props.loop && this.state.total > 1) {
+        this.scrollView.scrollTo({...offset, animated: false})
+        this.initialRender = false;
+      }
+    }
+
     this.setState(state)
   }
 


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- fix #570 

### Describe what you've done:
Just added a Swiper flag to track the initial render, and executed scrollView.scrollTo method with the appropriate offset.

### How to test it?
* Use react 0.48.0 with default example from react-native-swiper README.
* it will reproduce the buggy behavior when contentOffset is not applied to ScrollView. (Last page will be displayed first.)
* Apply the current patch. The scrollView.scrollTo should scroll to proper offset on first 'onLayout' call of Swiper.

It is applied only if there are more than 1 slides.
