### PR TITLE
Fix wrong calculation of width and height after device rotation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,6 @@ import {
   ActivityIndicator
 } from 'react-native'
 
-const { width, height } = Dimensions.get('window')
-
 /**
  * Default styles
  * @type {StyleSheetPropType}
@@ -224,6 +222,8 @@ export default class extends Component {
     }
 
     // Default: horizontal
+    const { width, height } = Dimensions.get('window')
+
     initState.dir = props.horizontal === false ? 'y' : 'x'
     initState.width = props.width || width
     initState.height = props.height || height


### PR DESCRIPTION
### Is it a bugfix?
- Yes
- Issue (fix #36)

### Describe what you've done:
- I moved code that gets width and height to the initState() function

### Steps to reproduce the issue (iOS):
Precondition:
`
<Swiper
    index={this.state.selectedPageIndex}
    onIndexChanged={(index) => this.setState({ selectedPageIndex: index })}>
    <SomeView/>
</Swiper>
`
- Add function to handle onIndexChanged
- Pass updatedIndex

Steps:
- Rotate device
- Swipe