### PR TITLE
add array to dotStyles propTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,8 +137,8 @@ export default class extends Component {
     autoplayDirection: PropTypes.bool,
     index: PropTypes.number,
     renderPagination: PropTypes.func,
-    dotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
-    activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+    dotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+    activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     dotColor: PropTypes.string,
     activeDotColor: PropTypes.string,
     /**


### PR DESCRIPTION
### Is it a bugfix ?
- Yes

### Is it a new feature ?
- No

### Describe what you've done:
style can be array.

### How to test it ?
set dotStyles using array
```
<Swiper 
  dotStyle={styles.scrollDotStyle}
  activeDotStyle={[styles.scrollDotStyle,{ backgroundColor: '#686868'}]}>
```