### PR TITLE
Dont Mix `import` and `module.exports` statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-import Swiper from './src/'
+var Swiper = require('./src/')
 module.exports = Swiper


### PR DESCRIPTION
I ran into this issue when trying to use this with webpack 2.2.0. See https://github.com/webpack/webpack/issues/4039
