### PR TITLE
Add a shrinkPagination Mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | dotColor | - | `string` | Allow custom the active-dot element. |
 | activeDotColor | - | `string` | Allow custom the active-dot element. |
 | activeDotStyle | - | `object` | Allow custom the active-dot element. |
+| briefPagination | false | `bool` | Set to `true` make briefPagination mode. |
+| visibleDotQuantity | 7 | `number` | Set to display the number of dots in brief mode. Values can take the following values. `3`、`5`、`7`、`9` |
+| dotWidth | 14 | `number` | If you set the style of the dot, you must modify this value, otherwise it will cause slip errors. This value is generally `width` + `padding` + `margin` |
 
 #### Autoplay
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | dotColor | - | `string` | Allow custom the active-dot element. |
 | activeDotColor | - | `string` | Allow custom the active-dot element. |
 | activeDotStyle | - | `object` | Allow custom the active-dot element. |
-| briefPagination | false | `bool` | Set to `true` make briefPagination mode. |
+| briefPagination | false | `bool` | Set to `true` make briefPagination mode. Of course, the total number of the carousel figure must be greater than the value of `visibleDotQuantity`. |
 | visibleDotQuantity | 7 | `number` | Set to display the number of dots in brief mode. Values can take the following values. `3`、`5`、`7`、`9` |
 | dotWidth | 14 | `number` | If you set the style of the dot, you must modify this value, otherwise it will cause slip errors. This value is generally `width` + `padding` + `margin` |
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | activeDotStyle | - | `object` | Allow custom the active-dot element. |
 | shrinkPagination | false | `bool` | Set to `true` make shrinkPagination mode. Of course, the total number of the carousel figure must be greater than the value of `visibleDotQuantity`. |
 | paginationDotCount | 7 | `number` | Set to display the number of dots in shrink mode. Values can take the following values `3`、`5`、`7`、`9`. |
-| dotSize | 14 | `number` | This means `width` and `height`. If you set the style of the dot, you must modify this value, otherwise it will cause slip errors. We usually render the dot`s height equal to the width. This value is generally `width` + `padding` + `margin` |
+| dotSize | 14 | `number` | This means `width` and `height`. If you set the style of the dot, you must modify this value, otherwise it will cause slip errors. We usually render the dot's height equal to the width. This value is generally `width` + `padding` + `margin` |
 
 #### Autoplay
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | dotColor | - | `string` | Allow custom the active-dot element. |
 | activeDotColor | - | `string` | Allow custom the active-dot element. |
 | activeDotStyle | - | `object` | Allow custom the active-dot element. |
-| briefPagination | false | `bool` | Set to `true` make briefPagination mode. Of course, the total number of the carousel figure must be greater than the value of `visibleDotQuantity`. |
-| visibleDotQuantity | 7 | `number` | Set to display the number of dots in brief mode. Values can take the following values. `3`、`5`、`7`、`9` |
-| dotWidth | 14 | `number` | If you set the style of the dot, you must modify this value, otherwise it will cause slip errors. This value is generally `width` + `padding` + `margin` |
+| shrinkPagination | false | `bool` | Set to `true` make shrinkPagination mode. Of course, the total number of the carousel figure must be greater than the value of `visibleDotQuantity`. |
+| paginationDotCount | 7 | `number` | Set to display the number of dots in shrink mode. Values can take the following values `3`、`5`、`7`、`9`. |
+| dotSize | 14 | `number` | This means `width` and `height`. If you set the style of the dot, you must modify this value, otherwise it will cause slip errors. We usually render the dot`s height equal to the width. This value is generally `width` + `padding` + `margin` |
 
 #### Autoplay
 

--- a/src/index.js
+++ b/src/index.js
@@ -172,9 +172,9 @@ export default class extends Component {
     autoplayDirection: true,
     index: 0,
     onIndexChanged: () => null,
-    briefPagination: false,
-    visibleDotQuantity: 7,
-    dotWidth: 14
+    shrinkPagination: false,
+    paginationDotCount: 7,
+    dotSize: 14
   }
 
   /**
@@ -259,7 +259,7 @@ export default class extends Component {
       ? height * props.index
       : width * props.index
 
-    initState.criticalValue = Math.ceil(props.visibleDotQuantity / 2) - 1;
+    initState.animationStartIndex = Math.ceil(props.paginationDotCount / 2) - 1;
 
     this.internals = {
       ...this.internals,
@@ -371,19 +371,26 @@ export default class extends Component {
       // if `onMomentumScrollEnd` registered will be called here
       this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e, this.fullState(), this)
 
-      // if props.briefPagination is false or this.scrollViewDot is false
-      if (!this.props.briefPagination || !this.scrollViewDot) {
+      // if props.shrinkPagination is false or this.scrollViewDot is false
+      if (!this.props.shrinkPagination || !this.scrollViewDot) {
         return;
       }
       // dot sliding logic
-      if (this.state.index > this.state.criticalValue && this.state.index < this.state.total - this.state.criticalValue) {
-        this.scrollViewDot.scrollTo({ x: (this.state.index - this.state.criticalValue) * this.props.dotWidth, y: 0, animated: true })
+      if (this.state.index > this.state.animationStartIndex && this.state.index < this.state.total - this.state.animationStartIndex) {
+        this.scrollViewDot.scrollTo({
+          x: this.props.horizontal ? (this.state.index - this.state.animationStartIndex) * this.props.dotSize : 0,
+          y: !this.props.horizontal ? (this.state.index - this.state.animationStartIndex) * this.props.dotSize : 0,
+          animated: true
+        })
       }
-      if (this.state.index === 0 || this.state.index === this.state.criticalValue) {
+      if (this.state.index === 0 || this.state.index === this.state.animationStartIndex) {
         this.scrollViewDot.scrollTo({ x: 0, y: 0, animated: true })
       }
       if (this.state.index === this.state.total - 1) {
-        this.scrollViewDot.scrollTo({ x: (this.state.total - this.props.visibleDotQuantity) * this.props.dotWidth, y: 0, animated: true })
+        this.scrollViewDot.scrollTo({
+          x: this.props.horizontal ? (this.state.total - this.props.paginationDotCount) * this.props.dotSize : 0,
+          y: !this.props.horizontal ? (this.state.total - this.props.paginationDotCount) * this.props.dotSize : 0
+        })
       }
     })
   }
@@ -539,8 +546,8 @@ export default class extends Component {
    * @return {object} react-dom
    */
   renderPagination = () => {
-    const { width } = Dimensions.get('window')
-    const { briefPagination, visibleDotQuantity, dotWidth } = this.props;
+    const { width, height } = Dimensions.get('window')
+    const { shrinkPagination, paginationDotCount, dotSize } = this.props;
      // By default, dots only show when `total` >= 2
     if (this.state.total <= 1) return null
 
@@ -572,21 +579,27 @@ export default class extends Component {
       )
     }
 
-    // briefPagination modal.
-    if (briefPagination && this.state.total > visibleDotQuantity && [3, 5, 7, 9].includes(visibleDotQuantity)) {
+    // shrinkPagination modal.
+    if (shrinkPagination && this.state.total > paginationDotCount && [3, 5, 7, 9].includes(paginationDotCount)) {
+      const shrinkPaginationViewStyle = this.props.horizontal
+      ? {
+       width: paginationDotCount * dotSize,
+       left: (width - paginationDotCount * dotSize) / 2,
+      }
+      : {
+        height: paginationDotCount * dotSize,
+        top: (height - paginationDotCount * dotSize) / 2,
+      }
       return (
         <View style={[
           styles['pagination_' + this.state.dir],
           this.props.paginationStyle,
-          {
-           width: visibleDotQuantity * dotWidth,
-           left: (width - visibleDotQuantity * dotWidth) / 2,
-          },
+          shrinkPaginationViewStyle
         ]}>
          <ScrollView
           pointerEvents='none'
           ref={ref => (this.scrollViewDot = ref)}
-          horizontal={true}
+          horizontal={this.props.horizontal}
           showsHorizontalScrollIndicator={false}
          >
           {dots}

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,10 @@ export default class extends Component {
     autoplayTimeout: 2.5,
     autoplayDirection: true,
     index: 0,
-    onIndexChanged: () => null
+    onIndexChanged: () => null,
+    briefPagination: false,
+    visibleDotQuantity: 7,
+    dotWidth: 14
   }
 
   /**
@@ -256,6 +259,7 @@ export default class extends Component {
       ? height * props.index
       : width * props.index
 
+    initState.criticalValue = Math.ceil(props.visibleDotQuantity / 2) - 1;
 
     this.internals = {
       ...this.internals,
@@ -366,6 +370,21 @@ export default class extends Component {
 
       // if `onMomentumScrollEnd` registered will be called here
       this.props.onMomentumScrollEnd && this.props.onMomentumScrollEnd(e, this.fullState(), this)
+
+      // if props.briefPagination is false or this.scrollViewDot is false
+      if (!this.props.briefPagination || !this.scrollViewDot) {
+        return;
+      }
+      // dot sliding logic
+      if (this.state.index > this.state.criticalValue && this.state.index < this.state.total - this.state.criticalValue) {
+        this.scrollViewDot.scrollTo({ x: (this.state.index - this.state.criticalValue) * this.props.dotWidth, y: 0, animated: true })
+      }
+      if (this.state.index === 0 || this.state.index === this.state.criticalValue) {
+        this.scrollViewDot.scrollTo({ x: 0, y: 0, animated: true })
+      }
+      if (this.state.index === this.state.total - 1) {
+        this.scrollViewDot.scrollTo({ x: (this.state.total - this.props.visibleDotQuantity) * this.props.dotWidth, y: 0, animated: true })
+      }
     })
   }
 
@@ -520,6 +539,8 @@ export default class extends Component {
    * @return {object} react-dom
    */
   renderPagination = () => {
+    const { width } = Dimensions.get('window')
+    const { briefPagination, visibleDotQuantity, dotWidth } = this.props;
      // By default, dots only show when `total` >= 2
     if (this.state.total <= 1) return null
 
@@ -548,6 +569,29 @@ export default class extends Component {
       dots.push(i === this.state.index
         ? React.cloneElement(ActiveDot, {key: i})
         : React.cloneElement(Dot, {key: i})
+      )
+    }
+
+    // briefPagination modal.
+    if (briefPagination && this.state.total > visibleDotQuantity && [3, 5, 7, 9].includes(visibleDotQuantity)) {
+      return (
+        <View style={[
+          styles['pagination_' + this.state.dir],
+          this.props.paginationStyle,
+          {
+           width: visibleDotQuantity * dotWidth,
+           left: (width - visibleDotQuantity * dotWidth) / 2,
+          },
+        ]}>
+         <ScrollView
+          pointerEvents='none'
+          ref={ref => (this.scrollViewDot = ref)}
+          horizontal={true}
+          showsHorizontalScrollIndicator={false}
+         >
+          {dots}
+         </ScrollView>
+        </View>
       )
     }
 


### PR DESCRIPTION
### Is it a bugfix ?
- No

### Is it a new feature ?
- Yes

### Describe what you've done:
In order to solve the excessive number of rounds, resulting in a large number of points. I added a reduced version of the pagination, I use the React-Native `ScrollView` completed, the animation is used `ScrollView` own `srcollTo` complete, and adapt to the horizontal and vertical sliding.
### How to test it ?

I carried out a full range of tests, the current sliding in the horizontal and vertical direction is no problem.