### PR TITLE
fix #503, fix a bug where onIndexChanged and onMomentumScrollEnd not …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -271,7 +271,7 @@ export default class extends Component {
 
   onLayout = (event) => {
     const { width, height } = event.nativeEvent.layout
-    const offset = this.internals.offset = {}
+    const offset = this.internals.offset = {x:0, y:0}
     const state = { width, height }
 
     if (this.state.total > 1) {


### PR DESCRIPTION
…firing when load content after init swiper

### Is it a bugfix ?
- Yes or No ?
- If yes, which issue (fix #number) ?
Yes, fix #503 

### Is it a new feature ?
- Yes or no ?
- Include documentation, demo GIF if applicable
no

### Describe what you've done:
give this.internals.offset init values 0 instead of empty obj

### How to test it ?
