### PR TITLE
Fix#626 :  Update this.internals when receiving new props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -258,7 +258,7 @@ export default class extends Component {
 
 
     this.internals = {
-      ...this.internals,
+      offset: initState.offset,
       isScrolling: false
     };
     return initState


### PR DESCRIPTION
### Explain Defect
E.g. swiper has 5 pages in x direction, scroll to last page, so ```this.internals.offset= {x: 4*width}```, then remove last page from swiper, but this.internals.offset isn't updated which still points to invalid position. When scrolling to the page before next last page,   ```const diff = offset[dir] - this.internals.offset[dir]``` in ```updateIndex``` function will be ```2``` which should be ```1```. 

### Explain Code Change
In initState function, state is calculated with new offset, internals' offset should also update to the new index page's offset.

### Is it a bugfix ?
- Yes or No ?
   Yes
- If yes, which issue (fix #number) ?
   #626

### Is it a new feature ?
- Yes or no ?
    No

### Describe what you've done:
Update this.internals offset when receiving new props.