### PR TITLE
init offset in initState function and prevent offset be overwritten when nextProps dosnt contain custom index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -256,9 +256,18 @@ export default class extends Component {
       ? height * props.index
       : width * props.index
 
+    // fix render last page first when loop = true
+    if (props.loop) {
+      initState.offset[initState.dir] = initState.dir === 'y'
+        ? height * (props.index + 1)
+        : width * (props.index + 1)
+    }
+
 
     this.internals = {
       ...this.internals,
+      // set initial offset
+      offset: initState.offset,
       isScrolling: false
     };
     return initState
@@ -271,18 +280,24 @@ export default class extends Component {
 
   onLayout = (event) => {
     const { width, height } = event.nativeEvent.layout
-    const offset = this.internals.offset = {}
+    // if I have only one image as placeholder, and replace it when other images loaded,
+    // updateIndex would never be triggered until Carousel re-render;
+    // because initial offset is undefined when children.length === 1
+    // offset[dir] minus internals.offset[dir] would be NaN,
+    // function updateIndex would return immediately.
+    const offset = this.internals.offset
     const state = { width, height }
 
-    if (this.state.total > 1) {
-      let setup = this.state.index
-      if (this.props.loop) {
-        setup++
-      }
-      offset[this.state.dir] = this.state.dir === 'y'
-        ? height * setup
-        : width * setup
-    }
+    // seems unnecessary
+    // if (this.state.total > 1) {
+    //   let setup = this.state.index
+    //   if (this.props.loop) {
+    //     setup++
+    //   }
+    //   offset[this.state.dir] = this.state.dir === 'y'
+    //     ? height * setup
+    //     : width * setup
+    // }
 
     // only update the offset in state if needed, updating offset while swiping
     // causes some bad jumping / stuttering

--- a/src/index.js
+++ b/src/index.js
@@ -252,22 +252,24 @@ export default class extends Component {
       initState.height = height;
     }
 
+    // since defaultProps of index is 0
+    // when nextProps didnt contain index, initial offset would be { 0, 0 }
     initState.offset[initState.dir] = initState.dir === 'y'
-      ? height * props.index
-      : width * props.index
+      ? height * initState.index
+      : width * initState.index;
 
     // fix render last page first when loop = true
     if (props.loop) {
       initState.offset[initState.dir] = initState.dir === 'y'
-        ? height * (props.index + 1)
-        : width * (props.index + 1)
+        ? height * (initState.index + 1)
+        : width * (initState.index + 1);
     }
 
 
     this.internals = {
-      ...this.internals,
       // set initial offset
       offset: initState.offset,
+      ...this.internals,
       isScrolling: false
     };
     return initState

--- a/src/index.js
+++ b/src/index.js
@@ -265,13 +265,18 @@ export default class extends Component {
         : width * (initState.index + 1);
     }
 
+    if (state.total === initState.total && !props.updateIndex) {
+      // retain the offset
+      initState.offset = this.internals.offset;
+    }
 
     this.internals = {
-      // set initial offset
-      offset: initState.offset,
       ...this.internals,
+      // update offset
+      offset: { ...initState.offset },
       isScrolling: false
     };
+
     return initState
   }
 


### PR DESCRIPTION
fix 2 cases.

If I pass only one child first then add children after sth loaded, updateIndex would never be triggered until next onLayout().
Internals.offset is an empty object after first onLayout() when total = 1, and onLayout triggered only once if I don't move the whole Swiper.

If props updated without a custom index, internals.offset would be overwritten by defaultProps of
index.