### PR TITLE
Handling of the dynamic flip of the autoplay prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "react-native",
     "ios"
   ],
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Swiper component for React Native.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "react-native",
     "ios"
   ],
-  "version": "1.5.14",
+  "version": "1.5.13",
   "description": "Swiper component for React Native.",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,11 @@ export default class extends Component {
     if (this.state.index !== nextState.index) this.props.onIndexChanged(nextState.index)
   }
 
+  componentDidUpdate(oldProps) {
+    // If the autoplay was programmatically enabled
+    if (!oldProps.autoplay && this.props.autoplay) this.autoplay()
+  }
+
   initState (props, updateIndex = false) {
     // set the current state
     const state = this.state || { width: 0, height: 0, offset: { x: 0, y: 0 } }

--- a/src/index.js
+++ b/src/index.js
@@ -355,6 +355,9 @@ export default class extends Component {
   onScrollEnd = e => {
     // update scroll state
     this.internals.isScrolling = false
+    this.setState({
+      autoplayEnd: false
+    })
 
     // making our events coming from android compatible to updateIndex logic
     if (!e.nativeEvent.contentOffset) {

--- a/src/index.js
+++ b/src/index.js
@@ -195,6 +195,10 @@ export default class extends Component {
   autoplayTimer = null
   loopJumpTimer = null
 
+  internals = {
+    offset: {}
+  }
+
   componentWillReceiveProps (nextProps) {
     if (!nextProps.autoplay && this.autoplayTimer) clearTimeout(this.autoplayTimer)
     this.setState(this.initState(nextProps, this.props.index !== nextProps.index))
@@ -401,6 +405,10 @@ export default class extends Component {
    * @param  {string} dir    'x' || 'y'
    */
   updateIndex = (offset, dir, cb) => {
+    if (!this.internals.offset[dir] && this.internals.offset[dir] !== 0) {
+      return;
+    }
+
     const state = this.state
     let index = state.index
     const diff = offset[dir] - this.internals.offset[dir]

--- a/src/index.js
+++ b/src/index.js
@@ -281,15 +281,13 @@ export default class extends Component {
     const offset = this.internals.offset = {}
     const state = { width, height }
 
-    if (this.state.total > 1) {
-      let setup = this.state.index
-      if (this.props.loop) {
-        setup++
-      }
-      offset[this.state.dir] = this.state.dir === 'y'
-        ? height * setup
-        : width * setup
+    let setup = this.state.index
+    if (this.props.loop) {
+      setup++
     }
+    offset[this.state.dir] = this.state.dir === 'y'
+      ? height * setup
+      : width * setup
 
     // only update the offset in state if needed, updating offset while swiping
     // causes some bad jumping / stuttering

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,8 @@ export default class extends Component {
     /**
      * Called when the index has changed because the user swiped.
      */
-    onIndexChanged: PropTypes.func
+    onIndexChanged: PropTypes.func,
+    onLayoutReady: PropTypes.func
   }
 
   /**
@@ -171,7 +172,8 @@ export default class extends Component {
     autoplayTimeout: 2.5,
     autoplayDirection: true,
     index: 0,
-    onIndexChanged: () => null
+    onIndexChanged: () => null,
+    onLayoutReady: () => null
   }
 
   /**
@@ -305,7 +307,7 @@ export default class extends Component {
       }
     }
 
-    this.setState(state)
+    this.setState(state, this.props.onLayoutReady)
   }
 
   loopJump = () => {


### PR DESCRIPTION
Fixing #225 #575 #241

Description:
When you programmatically flip the autoplay prop from true to false, Swiper handles it by killing the timer to stop auto swiping. But there is no handling for the case when autoplay is flipped from false to true to re-enable autoplay.

How to test:
Init Swiper with autoplay = false. Then programmatically set it to true (e.g. by changing the state). Autoplay should be resumed again.
