### PR TITLE
use device window dimension to avoid ios offset bug when index is specified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -270,7 +270,7 @@ export default class extends Component {
   }
 
   onLayout = (event) => {
-    const { width, height } = event.nativeEvent.layout
+    const { width, height } = Dimensions.get('window')
     const offset = this.internals.offset = {}
     const state = { width, height }
 


### PR DESCRIPTION
### Is it a bugfix ?
- Yes, no issue created

### Is it a new feature ?
- no

### Describe what you've done:
onLayout now uses device window dimensions to calculate offset rather than layout information in the event.

### How to test it ?
use the swiper, swipe to 3rd slide of 4 slides, having set index prop to redux store prop to maintain it on orientation, change device orientation, observe no offset bug in ios