### PR TITLE
Android vertical swiper

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "react-native",
     "ios"
   ],
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Swiper component for React Native.",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
  * react-native-swiper
  * @author leecade<leecade@163.com>
  */
+import { StyleSheet } from 'react-native'
+import VertViewPager from 'react-native-vertical-view-pager'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import {
@@ -636,16 +638,30 @@ export default class extends Component {
         </ScrollView>
        )
     }
-    return (
-      <ViewPagerAndroid ref={this.refScrollView}
-        {...this.props}
-        initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
-        onPageSelected={this.onScrollEnd}
-        key={pages.length}
-        style={[styles.wrapperAndroid, this.props.style]}>
-        {pages}
-      </ViewPagerAndroid>
-    )
+    if (this.props.horizontal === false) {
+          return (
+            <VertViewPager ref={this.refScrollView}
+                           {...this.props}
+                           initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
+                           onPageSelected={this.onScrollEnd}
+                           key={pages.length}
+                           style={StyleSheet.flatten([styles.wrapperAndroid, this.props.style])}>
+              {pages}
+            </VertViewPager>
+          )
+        } else {
+          return (
+            <ViewPagerAndroid ref={this.refScrollView}
+                              {...this.props}
+                              initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
+                              onPageSelected={this.onScrollEnd}
+                              key={pages.length}
+                              style={[styles.wrapperAndroid, this.props.style]}>
+              {pages}
+            </ViewPagerAndroid>
+          )
+
+        }
   }
 
   /**


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- If yes, which issue (fix #595 ) ?

### Is it a new feature ?
No
It's a bug fix for  nested vertical swiper not being displayed on Android (with `horizontal={false}` ).

### Describe what you've done:
I included a vertical view pager for Android

### How to test it ?
This example is provided on issue #595 :

<https://github.com/Robom11/react-native-swiper/blob/master/examples/components/Basic/index.js>
