### PR TITLE
export props from index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'react-native-swiper' {
     import { ViewStyle } from 'react-native'
     import { Component } from 'react'
 
-    interface SwiperProps {
+    export interface SwiperProps {
         // Basic
         // If true, the scroll view's children are arranged horizontally in a row instead of vertically in a column.
         horizontal?: boolean


### PR DESCRIPTION
### Is it a bugfix ?
No

### Is it a new feature ?
No

### Describe what you've done:
Export the prop type from `index.d.ts`.
Many times I don't use a full class for a simple component and just want the prop types


### How to test it ?
`import { SwiperProps } from 'react-native-swiper';`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leecade/react-native-swiper/644)
<!-- Reviewable:end -->
