### PR TITLE
Ability to customize buttons and correct positioning of vertical buttons in base implementation.

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -6,4 +6,5 @@ import Basic from './components/Basic/'
 // import PhotoView from './components/PhotoView/' // not working
 // import Swiper from './components/Swiper/'  // working but no title displayed
 // import SwiperNumber from './components/SwiperNumber/' // working but no title displayed
+// import Customization from './components/Customization/'
 AppRegistry.registerComponent('examples', () => Basic);

--- a/examples/components/Customization/index.js
+++ b/examples/components/Customization/index.js
@@ -1,0 +1,255 @@
+import React from 'react'
+import {
+  Text,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import Swiper from 'react-native-swiper'
+
+const Dimensions = require('Dimensions')
+const window = Dimensions.get('window')
+
+const justification = {
+  flex: 1,
+  justifyContent: 'center',
+  alignItems: 'center'
+}
+const justification2 = {
+  flex: 1,
+  alignItems: 'center'
+}
+const styles = {
+  wrapper: {
+    backgroundColor: 'transparent'
+  },
+  innerSwiper: {
+    width: window.width,
+    height: window.height / 3,
+    marginTop: 60,
+    backgroundColor: '#92BBD9'
+  },
+  slide1: {
+    ...justification,
+    backgroundColor: '#9DD6EB'
+  },
+  slide2: {
+    ...justification,
+    backgroundColor: '#97CAE5'
+  },
+  slide3: {
+    ...justification,
+    backgroundColor: '#92BBD9'
+  },
+  slide4: {
+    ...justification2,
+    backgroundColor: '#D6EB9D'
+  },
+  slide5: {
+    ...justification,
+    backgroundColor: '#CAE597'
+  },
+  slide6: {
+    ...justification,
+    backgroundColor: '#BBD992'
+  },
+  text: {
+    color: '#fff',
+    fontSize: 30,
+    fontWeight: 'bold'
+  },
+  pagination_x: {
+    position: 'absolute',
+    top: 45, // changed from the default.
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'transparent'
+  },
+
+  pagination_y: {
+    position: 'absolute',
+    left: 15, // changed from default.
+    top: 0,
+    bottom: 0,
+    flexDirection: 'column',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'transparent'
+  },
+
+  buttonWrapper_x: {
+    backgroundColor: 'transparent',
+    flexDirection: 'row',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    flex: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+
+  buttonWrapper_y: {
+    backgroundColor: 'transparent',
+    flexDirection: 'column-reverse',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    flex: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+
+  horizontalButtonText: {
+    fontSize: 50,
+    color: '#007aff'
+  },
+  verticalButtonText: {
+    fontSize: 50,
+    color: '#007aff'
+    // transform: [ {rotate: '90deg'} ]
+  }
+}
+const renderNextButton = (index, total, context) => {
+  let button = null
+
+  if (context.props.loop ||
+    index !== total - 1) {
+    if (context.props.horizontal) {
+      button = context.props.nextButton || <Text style={styles.horizontalButtonText}>right</Text>
+    } else {
+      button = context.props.nextButton || <Text style={styles.verticalButtonText}>bottom</Text>
+    }
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={() => button !== null && context.scrollBy(1)}
+      disabled={context.props.disableNextButton}
+    >
+      <View>
+        {button}
+      </View>
+    </TouchableOpacity>
+  )
+}
+
+const renderPrevButton = (index, total, context) => {
+  let button = null
+
+  if (context.props.loop || this.state.index !== 0) {
+    if (context.props.horizontal) {
+      button = context.props.prevButton || <Text style={styles.horizontalButtonText}>left</Text>
+    } else {
+      button = context.props.prevButton || <Text style={styles.verticalButtonText}>top</Text>
+    }
+  }
+
+  return (
+    <TouchableOpacity onPress={() => button !== null && context.scrollBy(-1)}>
+      <View>
+        {button}
+      </View>
+    </TouchableOpacity>
+  )
+}
+const renderButtons2 = (index, total, context) => {
+  if (context.props.horizontal) {
+    return (
+      <View pointerEvents='box-none' style={[styles.buttonWrapper_x, {
+        width: context.state.width,
+        height: context.state.height
+      }, context.props.buttonWrapperStyle]}>
+        {renderPrevButton(index, total, context)}
+        {renderNextButton(index, total, context)}
+      </View>
+    )
+  } else {
+    return (
+      <View pointerEvents='box-none' style={[styles.buttonWrapper_y, {
+        width: context.state.width,
+        height: context.state.height
+      }, context.props.buttonWrapperStyle]}>
+        {renderNextButton(index, total, context)}
+        {renderPrevButton(index, total, context)}
+      </View>
+    )
+  }
+}
+const renderPagination2 = (index, total, context) => {
+  // By default, dots only show when `total` >= 2
+  if (context.state.total <= 1) return null
+
+  let dots = []
+  const ActiveDot = context.props.activeDot || <View style={[{
+    backgroundColor: context.props.activeDotColor || '#007aff',
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginLeft: 3,
+    marginRight: 3,
+    marginTop: 3,
+    marginBottom: 3
+  }, context.props.activeDotStyle]} />
+  const Dot = context.props.dot || <View style={[{
+    backgroundColor: context.props.dotColor || 'rgba(0,0,0,.2)',
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginLeft: 3,
+    marginRight: 3,
+    marginTop: 3,
+    marginBottom: 3
+  }, context.props.dotStyle]} />
+  for (let i = 0; i < context.state.total; i++) {
+    dots.push(i === context.state.index
+      ? React.cloneElement(ActiveDot, {key: i})
+      : React.cloneElement(Dot, {key: i})
+    )
+  }
+
+  return (
+    <View pointerEvents='none' style={[styles['pagination_' + context.state.dir], context.props.paginationStyle]}>
+      {dots}
+    </View>
+  )
+}
+export default () =>
+  <Swiper style={styles.wrapper} showsButtons horizontal={false} showsPagination renderPagination={renderPagination2}
+    renderButtons={renderButtons2}>
+
+    <View style={styles.slide4}>
+      <View style={styles.innerSwiper}>
+        <Swiper style={styles.wrapper} showsButtons showsPagination renderPagination={renderPagination2}
+          renderButtons={renderButtons2}>
+
+          <View style={styles.slide1}>
+            <Text style={styles.text}>Horiz Panel 1</Text>
+          </View>
+
+          <View style={styles.slide2}>
+            <Text style={styles.text}>Horiz Panel 2</Text>
+          </View>
+
+          <View style={styles.slide3}>
+            <Text style={styles.text}>Horiz Panel 3</Text>
+          </View>
+
+        </Swiper>
+      </View>
+      <Text style={styles.text}>Vertical Panel 1</Text>
+    </View>
+    <View style={styles.slide5}>
+      <Text style={styles.text}>Vertical Panel 2</Text>
+    </View>
+    <View style={styles.slide6}>
+      <Text style={styles.text}>Vertical Panel 3</Text>
+    </View>
+  </Swiper>

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const styles = {
     backgroundColor: 'transparent'
   },
 
-  buttonWrapper: {
+  buttonWrapper_x: {
     backgroundColor: 'transparent',
     flexDirection: 'row',
     position: 'absolute',
@@ -89,10 +89,27 @@ const styles = {
     alignItems: 'center'
   },
 
-  buttonText: {
+  buttonWrapper_y: {
+    backgroundColor: 'transparent',
+    flexDirection: 'column-reverse',
+    position: 'absolute',
+    top: 20,
+    left: 0,
+    flex: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+
+  horizontalButtonText: {
     fontSize: 50,
     color: '#007aff',
-    fontFamily: 'Arial'
+  },
+  verticalButtonText: {
+    fontSize: 50,
+    color: '#007aff',
+    transform: [ {rotate: '90deg'} ]
   }
 }
 
@@ -573,7 +590,11 @@ export default class extends Component {
 
     if (this.props.loop ||
       this.state.index !== this.state.total - 1) {
-      button = this.props.nextButton || <Text style={styles.buttonText}>›</Text>
+      if (this.props.horizontal) {
+        button = this.props.nextButton || <Text style={styles.horizontalButtonText}>›</Text>
+      } else {
+        button = this.props.nextButton || <Text style={styles.verticalButtonText}>›</Text>
+      }
     }
 
     return (
@@ -592,7 +613,11 @@ export default class extends Component {
     let button = null
 
     if (this.props.loop || this.state.index !== 0) {
-      button = this.props.prevButton || <Text style={styles.buttonText}>‹</Text>
+      if (this.props.horizontal) {
+        button = this.props.prevButton || <Text style={styles.horizontalButtonText}>‹</Text>
+      } else {
+        button = this.props.prevButton || <Text style={styles.verticalButtonText}>‹</Text>
+      }
     }
 
     return (
@@ -605,15 +630,28 @@ export default class extends Component {
   }
 
   renderButtons = () => {
-    return (
-      <View pointerEvents='box-none' style={[styles.buttonWrapper, {
-        width: this.state.width,
-        height: this.state.height
-      }, this.props.buttonWrapperStyle]}>
-        {this.renderPrevButton()}
-        {this.renderNextButton()}
-      </View>
-    )
+    if (this.props.horizontal) {
+      return (
+        <View pointerEvents='box-none' style={[styles.buttonWrapper_x, {
+          width: this.state.width,
+          height: this.state.height
+        }, this.props.buttonWrapperStyle]}>
+          {this.renderPrevButton()}
+          {this.renderNextButton()}
+        </View>
+      )
+    }
+    else {
+      return (
+        <View pointerEvents='box-none' style={[styles.buttonWrapper_y, {
+          width: this.state.width,
+          height: this.state.height
+        }, this.props.buttonWrapperStyle]}>
+          {this.renderNextButton()}
+          {this.renderPrevButton()}
+        </View>
+      )
+    }
   }
 
   refScrollView = view => {

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,7 @@ export default class extends Component {
     autoplayDirection: PropTypes.bool,
     index: PropTypes.number,
     renderPagination: PropTypes.func,
+    renderButtons: PropTypes.func,
     dotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     dotColor: PropTypes.string,
@@ -522,6 +523,7 @@ export default class extends Component {
       if (typeof props[prop] === 'function' &&
         prop !== 'onMomentumScrollEnd' &&
         prop !== 'renderPagination' &&
+        prop !== 'renderButtons' &&
         prop !== 'onScrollBeginDrag'
       ) {
         let originResponder = props[prop]
@@ -707,6 +709,7 @@ export default class extends Component {
       loadMinimalSize,
       loadMinimalLoader,
       renderPagination,
+      renderButtons,
       showsButtons,
       showsPagination,
     } = this.props;
@@ -756,9 +759,14 @@ export default class extends Component {
     return (
       <View style={[styles.container, containerStyle]} onLayout={this.onLayout}>
         {this.renderScrollView(pages)}
-        {showsPagination && (renderPagination
+        {showsPagination &&
+        (renderPagination
           ? renderPagination(index, total, this)
           : this.renderPagination())}
+        {showsButtons &&
+        (renderButtons
+          ? renderButtons(index, total, this)
+          : this.renderButtons())}
         {this.renderTitle()}
         {showsButtons && this.renderButtons()}
       </View>


### PR DESCRIPTION
### Is it a bugfix ? 
No, unless button positioning is a bug.
### Is it a new feature ? 
Yes: ability to customize buttons in the same way as pagination dots.

An example is provided in examples/components/Customization/index.js

### Describe what you've done:

I have made it so in the base implementation, if horizontal=false is used and vertical swiping is the behaviour, the buttons for next and previous show on the top and bottom by default.

I have also provided a way to customize the style of the buttons in the same way that pagination can be customized.

### How to test it ?
Test code is provided in the example given in examples/components/Customization/index.js.