### PR TITLE
Use the dynamically calculated width and height when determining initial offset.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,8 +253,8 @@ export default class extends Component {
     }
 
     initState.offset[initState.dir] = initState.dir === 'y'
-      ? height * props.index
-      : width * props.index
+      ? initState.height * props.index
+      : initState.width * props.index
 
 
     this.internals = {


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- fixes #651

### Is it a new feature ?
- No

### Describe what you've done:

Rather than always using the `Dimensions.get('window')` width/height to scroll the view, we use the calculated width/height that's used elsewhere.

### How to test it ?

Create a view in the same way that I've outlined in #651 and verify that on load the box shows completely orange.