### PR TITLE
Provide default value to diff, protect NaN

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -395,7 +395,7 @@ export default class extends Component {
   updateIndex = (offset, dir, cb) => {
     const state = this.state
     let index = state.index
-    const diff = offset[dir] - this.internals.offset[dir]
+    const diff = offset[dir] - (this.internals.offset[dir] || 0)
     const step = dir === 'x' ? state.width : state.height
     let loopJump = false
 


### PR DESCRIPTION
### Is it a bugfix ?
- Possibly

### Is it a new feature ?
- Nope, just makes it work

### Describe what you've done:

Dots weren't representing their active index, noticed that in this line:

`const diff = offset[dir] - this.internals.offset[dir]`

`this.internals.offset[dir]` was often undefined, which resulted in diff being NaN. Gave it a default of 0.

### How to test it ?

Watch it work. 