### PR TITLE
Enable onScrollBeginDrag, onScrollSettlingDrag, & onScrollEndDrag for ViewPagerAndroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | Prop  | Params  | Type | Description |
 | :------------ |:---------------:| :---------------:| :-----|
 | onScrollBeginDrag | `e` / `state` / `context` | `function` | When animation begins after letting up |
+| onScrollSettlingDrag | `e` / `state` | `function` | Right before drag animation ends [Android] |
+| onScrollEndDrag | `e` / `state` / `context` | `function` | When animation ends after dragging |
 | onMomentumScrollEnd | `e` / `state` / `context` | `function` | Makes no sense why this occurs first during bounce |
 | onTouchStartCapture | `e` / `state` / `context` | `function` | Immediately after `onMomentumScrollEnd` |
 | onTouchStart | `e` / `state` / `context` | `function` | Same, but bubble phase |

--- a/src/index.js
+++ b/src/index.js
@@ -334,6 +334,26 @@ export default class extends Component {
   }
 
   /**
+   * [Android Only] Listens for scroll events
+   * @param  {string} e native event of values: 'dragging', 'settling', 'idle'
+   */
+  onPageScrollStateChanged(e) {
+    switch (e) {
+      case 'dragging':
+        this.internals.isScrolling = true
+        this.props.onScrollBeginDrag && this.props.onScrollBeginDrag(e, this.fullState())
+        break;
+      case 'settling':
+        this.props.onScrollSettlingDrag && this.props.onScrollSettlingDrag(e, this.fullState())
+        break;
+      case 'idle':
+        this.internals.isScrolling = false
+        this.props.onScrollEndDrag && this.props.onScrollEndDrag(e, this.fullState())
+        break;
+    }
+  }
+
+  /**
    * Scroll begin handle
    * @param  {object} e native event
    */
@@ -640,6 +660,7 @@ export default class extends Component {
       <ViewPagerAndroid ref={this.refScrollView}
         {...this.props}
         initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
+        onPageScrollStateChanged={this.onPageScrollStateChanged.bind(this)}
         onPageSelected={this.onScrollEnd}
         key={pages.length}
         style={[styles.wrapperAndroid, this.props.style]}>


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
-  Fixes issue #489 

### Is it a new feature ?
- No 

Please refer to [ViewPagerAndroid](https://facebook.github.io/react-native/docs/viewpagerandroid.html)
Android Swiper:
```

<Swiper 
    onScrollBeginDrag={this._onScrollBeginDrag.bind(this)}
    onScrollSettlingDrag={this._onScrollSettlingDrag.bind(this)}
    onScrollEndDrag={this._onScrollSettlingDrag.bind(this)}
 />

_onScrollBeginDrag(e) {
    console.log(e) // Logs 'dragging'
}

_onScrollSettlingDrag(e) {
    console.log(e) // Logs 'settling'
}

_onScrollEndDrag(e) {
    console.log(e) // Logs 'idle'
}



```
### Describe what you've done:

Utilized ViewPagerAndroid's native `onPageScrollStateChanged` prop to listen for scroll event changes and funneled the event through a `switch` operator which routes the 'dragging' event to `onScrollBeginDrag`, 'settling' to `onScrollSettlingDrag`, and 'idle' to `onScrollEndDrag` prop functions.

### How to test it ?

Use those prop functions inside an Android environment with the Swiper component and watch the return value of argument `e` in each of the cases as you drag.

### Disclaimer

These props only return `e` and `state` but not `context` because it would overflow my phone's memory each time I tried to console log the `context`. Therefore, I updated `onScrollSettlingDrag` in the README without the `context` argument but I didn't bother rearranging `onScrollBeginDrag` and `onScrollEndDrag` without [Android] missing `context` info to avoid cluttering that space.

- Just occurred to me, would this not have happened if I simply utilized `context` without trying to log the whole thing? But how would a user know what is available within the `context` without viewing it?