### PR TITLE
Add onScrollBegin and onTouchEnd for Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -620,6 +620,17 @@ export default class extends Component {
     this.scrollView = view;
   }
 
+  onPageScrollStateChanged = state => {
+    switch (state) {
+      case 'dragging':
+        return this.onScrollBegin();
+
+      case 'idle':
+      case 'settling':
+        if (this.props.onTouchEnd) this.props.onTouchEnd();
+    }
+  }
+
   renderScrollView = pages => {
     if (Platform.OS === 'ios') {
       return (
@@ -640,6 +651,7 @@ export default class extends Component {
       <ViewPagerAndroid ref={this.refScrollView}
         {...this.props}
         initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
+        onPageScrollStateChanged={this.onPageScrollStateChanged}
         onPageSelected={this.onScrollEnd}
         key={pages.length}
         style={[styles.wrapperAndroid, this.props.style]}>


### PR DESCRIPTION
### Is it a bugfix ?
Yes
https://github.com/leecade/react-native-swiper/issues/489

### Is it a new feature ?
No

### Describe what you've done:
The swiper is now listening on Android ViewPagerAndroid's onPageScrollStateChanged event.

### How to test it ?
Just use onScrollBeginDrag.