### PR TITLE
Fix bug that "cannot read property 'x' of undefined"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -393,6 +393,11 @@ export default class extends Component {
    * @param  {string} dir    'x' || 'y'
    */
   updateIndex = (offset, dir, cb) => {
+
+    if(offset === undefined || this.internals.offset === undefined){
+      return;
+    }
+
     const state = this.state
     let index = state.index
     const diff = offset[dir] - this.internals.offset[dir]


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- https://github.com/leecade/react-native-swiper/issues/582

### Is it a new feature ?
- No

### Describe what you've done:

Null check

### How to test it ?
Forking locally.