### PR TITLE
custom button style support.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,8 @@ export default class extends Component {
     /**
      * Called when the index has changed because the user swiped.
      */
-    onIndexChanged: PropTypes.func
+    onIndexChanged: PropTypes.func,
+    buttonTextStyle:PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
   }
 
   /**
@@ -171,7 +172,8 @@ export default class extends Component {
     autoplayTimeout: 2.5,
     autoplayDirection: true,
     index: 0,
-    onIndexChanged: () => null
+    onIndexChanged: () => null,
+    buttonTextStyle:undefined,
   }
 
   /**
@@ -573,7 +575,7 @@ export default class extends Component {
 
     if (this.props.loop ||
       this.state.index !== this.state.total - 1) {
-      button = this.props.nextButton || <Text style={styles.buttonText}>›</Text>
+      button = this.props.nextButton || <Text style={[styles.buttonText, this.props.buttonTextStyle]}>›</Text>
     }
 
     return (
@@ -592,7 +594,7 @@ export default class extends Component {
     let button = null
 
     if (this.props.loop || this.state.index !== 0) {
-      button = this.props.prevButton || <Text style={styles.buttonText}>‹</Text>
+      button = this.props.prevButton || <Text style={[styles.buttonText, this.props.buttonTextStyle]}>‹</Text>
     }
 
     return (


### PR DESCRIPTION
now we can pass buttonTextStyle as props to swiper that will override default props

### Is it a bugfix ?
- Yes or No ? NO
- If yes, which issue (fix #number) ?

### Is it a new feature ?
- Yes or no ? YES
- Include documentation, demo GIF if applicable
pass buttonTextStyle props to override default button style

### Describe what you've done:
edited renderNextButton and renderPrevButton functions to use buttonTextStyle from props
### How to test it ?
<Swiper
                   style={styles.wrapper}
                   showsButtons={true}
                   buttonTextStyle={{color:'#9e9e9e', fontSize:24}}    //pass your style in swiper component
                   showsPagination={false}
                   loadMinimal={true}
                   loadMinimalSize={2}
                   ref='listView'>
                   {Your_VIEWS_TO_RENDER}
               </Swiper>