### PR TITLE
Custom activity indicator color prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | loadMinimal | false | `bool` | Only load current index slide , `loadMinimalSize` slides before and after. |
 | loadMinimalSize | 1 | `number` | see `loadMinimal`   |
 | loadMinimalLoader | `<ActivityIndicator />` | `element` | Custom loader to display when slides aren't loaded
+| activityColor | `string` | Defines a color for the <ActivityIndicator> on the loading page. |
 
 #### Pagination
 
@@ -252,8 +253,6 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | Prop  | Params  | Type | Description |
 | :------------ |:---------------:| :---------------:| :-----|
 | onScrollBeginDrag | `e` / `state` / `context` | `function` | When animation begins after letting up |
-| onScrollSettlingDrag | `e` / `state` | `function` | Right before drag animation ends [Android] |
-| onScrollEndDrag | `e` / `state` / `context` | `function` | When animation ends after dragging |
 | onMomentumScrollEnd | `e` / `state` / `context` | `function` | Makes no sense why this occurs first during bounce |
 | onTouchStartCapture | `e` / `state` / `context` | `function` | Immediately after `onMomentumScrollEnd` |
 | onTouchStart | `e` / `state` / `context` | `function` | Same, but bubble phase |

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | loadMinimal | false | `bool` | Only load current index slide , `loadMinimalSize` slides before and after. |
 | loadMinimalSize | 1 | `number` | see `loadMinimal`   |
 | loadMinimalLoader | `<ActivityIndicator />` | `element` | Custom loader to display when slides aren't loaded
-| activityColor | `string` | Defines a color for the <ActivityIndicator> on the loading page. |
+| activityColor | `string` | Defines a color for the <ActivityIndicator/> on the loading page. |
 
 #### Pagination
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ AppRegistry.registerComponent('myproject', () => swiper);
 | Prop  | Params  | Type | Description |
 | :------------ |:---------------:| :---------------:| :-----|
 | onScrollBeginDrag | `e` / `state` / `context` | `function` | When animation begins after letting up |
+| onScrollSettlingDrag | `e` / `state` | `function` | Right before drag animation ends [Android] |
+| onScrollEndDrag | `e` / `state` / `context` | `function` | When animation ends after dragging |
 | onMomentumScrollEnd | `e` / `state` / `context` | `function` | Makes no sense why this occurs first during bounce |
 | onTouchStartCapture | `e` / `state` / `context` | `function` | Immediately after `onMomentumScrollEnd` |
 | onTouchStart | `e` / `state` / `context` | `function` | Same, but bubble phase |

--- a/src/index.js
+++ b/src/index.js
@@ -334,6 +334,26 @@ export default class extends Component {
   }
 
   /**
+   * [Android Only] Listens for scroll events
+   * @param  {string} e native event of values: 'dragging', 'settling', 'idle'
+   */
+  onPageScrollStateChanged(e) {
+    switch (e) {
+      case 'dragging':
+        this.internals.isScrolling = true
+        this.props.onScrollBeginDrag && this.props.onScrollBeginDrag(e, this.fullState())
+        break;
+      case 'settling':
+        this.props.onScrollSettlingDrag && this.props.onScrollSettlingDrag(e, this.fullState())
+        break;
+      case 'idle':
+        this.internals.isScrolling = false
+        this.props.onScrollEndDrag && this.props.onScrollEndDrag(e, this.fullState())
+        break;
+    }
+  }
+
+  /**
    * Scroll begin handle
    * @param  {object} e native event
    */
@@ -640,6 +660,7 @@ export default class extends Component {
       <ViewPagerAndroid ref={this.refScrollView}
         {...this.props}
         initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
+        onPageScrollStateChanged={this.onPageScrollStateChanged.bind(this)}
         onPageSelected={this.onScrollEnd}
         key={pages.length}
         style={[styles.wrapperAndroid, this.props.style]}>

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,7 @@ export default class extends Component {
     activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     dotColor: PropTypes.string,
     activeDotColor: PropTypes.string,
+    activityColor: PropTypes.string,
     /**
      * Called when the index has changed because the user swiped.
      */
@@ -331,26 +332,6 @@ export default class extends Component {
 
       this.scrollBy(this.props.autoplayDirection ? 1 : -1)
     }, this.props.autoplayTimeout * 1000)
-  }
-
-  /**
-   * [Android Only] Listens for scroll events
-   * @param  {string} e native event of values: 'dragging', 'settling', 'idle'
-   */
-  onPageScrollStateChanged(e) {
-    switch (e) {
-      case 'dragging':
-        this.internals.isScrolling = true
-        this.props.onScrollBeginDrag && this.props.onScrollBeginDrag(e, this.fullState())
-        break;
-      case 'settling':
-        this.props.onScrollSettlingDrag && this.props.onScrollSettlingDrag(e, this.fullState())
-        break;
-      case 'idle':
-        this.internals.isScrolling = false
-        this.props.onScrollEndDrag && this.props.onScrollEndDrag(e, this.fullState())
-        break;
-    }
   }
 
   /**
@@ -660,7 +641,6 @@ export default class extends Component {
       <ViewPagerAndroid ref={this.refScrollView}
         {...this.props}
         initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
-        onPageScrollStateChanged={this.onPageScrollStateChanged.bind(this)}
         onPageSelected={this.onScrollEnd}
         key={pages.length}
         style={[styles.wrapperAndroid, this.props.style]}>
@@ -724,7 +704,7 @@ export default class extends Component {
           } else {
             return (
               <View style={pageStyleLoading} key={i}>
-                {loadMinimalLoader ? loadMinimalLoader : <ActivityIndicator />}
+                {loadMinimalLoader ? loadMinimalLoader : <ActivityIndicator color={this.props.activityColor} />}
               </View>
             )
           }


### PR DESCRIPTION
### Is it a bugfix ?
No

### Is it a new feature ?
Yes

- Include documentation, demo GIF if applicable
Pass a string color to `activityColor` prop of Swiper to define a specific color for the `<ActivityIndicator color={ this.props.activityColor } />`.
:: <Swiper ...activityColor={ 'blue' } />

### Describe what you've done:
Allow passing a prop to `<Swiper />` that will define a specific color for the spinning ActivityIndicator icon. 

### How to test it ?
Pass an additional prop such as `activityColor={'#0077B5'}` to `<Swiper />` and check that the default color changes to the custom color.
