### PR TITLE
fix error on issue #583

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -392,6 +392,9 @@ export default class extends Component {
    * @param  {string} dir    'x' || 'y'
    */
   updateIndex = (offset, dir, cb) => {
+    if (offset === undefined || this.internals.offset === undefined) {
+      return;
+    }
     const state = this.state
     let index = state.index
     const diff = offset[dir] - this.internals.offset[dir]


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- fix issue #583

### Is it a new feature ?
- No

### Description :

![alt text](https://user-images.githubusercontent.com/17783665/30743091-c57aaf22-9fce-11e7-9cd1-c8f0ea47a45c.png "Screenshot") 

Sometimes there is an error popup and show "undefined is not an object (evaluating'_this.internals.offset[dir]')" message. I add some scripts to prevent that error appear again, based on @yoyo0427 does. 