### PR TITLE
fixing wrong offset on ios with loop enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,9 +251,10 @@ export default class extends Component {
       initState.height = height;
     }
 
+    const rIndex = this.getPageKeys().indexOf(props.index.toString());
     initState.offset[initState.dir] = initState.dir === 'y'
-      ? height * props.index
-      : width * props.index
+      ? height * rIndex
+      : width * rIndex
 
 
     this.internals = {
@@ -647,6 +648,17 @@ export default class extends Component {
     )
   }
 
+  getPageKeys() {
+    const pageKeys = Object.keys(this.props.children)
+    // Re-design a loop model for avoid img flickering
+    if (this.props.loop) {
+      pageKeys.unshift(pageKeys[pageKeys.length - 1] + '')
+      pageKeys.push('0')
+    }
+
+    return pageKeys;
+  }
+
   /**
    * Default render
    * @return {object} react-dom
@@ -687,12 +699,7 @@ export default class extends Component {
 
     // For make infinite at least total > 1
     if (total > 1) {
-      // Re-design a loop model for avoid img flickering
-      pages = Object.keys(children)
-      if (loop) {
-        pages.unshift(total - 1 + '')
-        pages.push('0')
-      }
+      pages = this.getPageKeys();
 
       pages = pages.map((page, i) => {
         if (loadMinimal) {


### PR DESCRIPTION
### Is it a bugfix ?
- Yes, not sure there is an issue opened though. 
When displaying a swiper on IOS, the first item displayed was not the actual first.

### Describe what you've done:
To handle looping an array is created (https://github.com/leecade/react-native-swiper/blob/master/src/index.js#L692), it contains the keys of the elements to display, then the last key is duplicated at the start of the array and the first key is duplicated at the end of the array. 

For example, if your swiper contains 3 elements, the array will first contains this : `['0', '1', '2']` and if looping is enabled additionals keys will be added : `['2', '0', '1', '2', '0']`.

When rendering, the swiper will by default place itself at offset 0 which will instead be the last element thas has been put at the start of the array for looping purpose.

To fix that, I added some code building the array earlier and I compute the offset by using the key position in the array.

