### PR TITLE
Add missing scrollBy definition to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,5 +102,11 @@ declare module 'react-native-swiper' {
     }
 
     export default class Swiper extends Component<SwiperProps, any> {
+        /**
+         * Scroll by index
+         * @param  {number} index offset index
+         * @param  {bool} animated default true
+         */
+        public scrollBy(index: number, animated?: boolean): void;
     }
 }


### PR DESCRIPTION
### Is it a bugfix ?
- Yes or No ? No

### Is it a new feature ?
- Yes or no ? Yes

### Describe what you've done:
Add the missing `scrollBy` definition to the Typescript typings