### PR TITLE
Updated docs to contain containerStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ AppRegistry.registerComponent('myproject', () => Swiper);
 | width | - | `number` | If no specify default enable fullscreen mode by `flex: 1`. |
 | height | - | `number` | If no specify default fullscreen mode by `flex: 1`. |
 | style | {...} | `style` | See default style in source. |
+| containerStyle | `{backgroundColor: 'transparent', position: 'relative', flex: 1}`  | `style` | Custom styles will merge with the default styles. |
 | loadMinimal | false | `bool` | Only load current index slide , `loadMinimalSize` slides before and after. |
 | loadMinimalSize | 1 | `number` | see `loadMinimal`   |
 | loadMinimalLoader | `<ActivityIndicator />` | `element` | Custom loader to display when slides aren't loaded


### PR DESCRIPTION
### Is it a bugfix ?
- Yes #767

### Is it a new feature ?
Added containerStyle to docs
```
| containerStyle | `{backgroundColor: 'transparent', position: 'relative', flex: 1}`  | `style` | Custom styles will merge with the default styles. |
```