### PR TITLE
chore: add scrollBy to typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,5 +102,6 @@ declare module 'react-native-swiper' {
     }
 
     export default class Swiper extends Component<SwiperProps, any> {
+        scrollBy(index: number, animated?: boolean): void
     }
 }


### PR DESCRIPTION
### Is it a bugfix?
No

### Is it a new feature?
No

### Describe what you've done:
Added scrollBy to the index.d.ts file

### How to test it?
```
import Swiper from 'react-native-swiper';

const x = new Swiper();
x.scrollBy(1); // should not error
```

I've tested this and all seems in order, cheers!