### PR TITLE
Add scrollBy to the Swiper TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,5 +102,6 @@ declare module 'react-native-swiper' {
     }
 
     export default class Swiper extends Component<SwiperProps, any> {
+        scrollBy(offset: number, animated?: boolean) : void
     }
 }


### PR DESCRIPTION
Add the missing scrollBy type to the TypeScript definitions.

### Is it a bugfix ?
- No

### Is it a new feature ?
- Yes
Just missing TypeScript types for the APIs that already exist.

### Describe what you've done:

This adds the TypeScript type for the scrollBy API that already exists so that it can be used from TS without casting to any. Since Swiper is a class it can't even be patched locally with type merges.

### How to test it ?
I don't see any automated tests yet. A manual test would consist of comparing the type with the actual JS API. If there were automated tests then any TypeScript test that uses the types would break if they fell out of sync with the implementation (in some cases). Let me know what you expect here.
