### PR TITLE
Support for onScrollEndDrag prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ AppRegistry.registerComponent('myproject', () => Swiper);
 
 | Prop  | Params  | Type | Description |
 | :------------ |:---------------:| :---------------:| :-----|
-| onScrollBeginDrag | `e` / `state` / `context` | `function` | When animation begins after letting up |
+| onScrollBeginDrag | `e` / `state` / `context` | `function` | When the user starts to drag |
+| onScrollEndDrag | `e` / `state` / `context` | `function` | When animation begins after letting up |
 | onMomentumScrollEnd | `e` / `state` / `context` | `function` | Makes no sense why this occurs first during bounce |
 | onTouchStartCapture | `e` / `state` / `context` | `function` | Immediately after `onMomentumScrollEnd` |
 | onTouchStart | `e` / `state` / `context` | `function` | Same, but bubble phase |

--- a/src/index.js
+++ b/src/index.js
@@ -384,6 +384,7 @@ export default class extends Component {
       (index === 0 || index === children.length - 1)) {
       this.internals.isScrolling = false
     }
+    this.props.onScrollEndDrag && this.props.onScrollEndDrag(e, this.fullState(), this)
   }
 
   /**


### PR DESCRIPTION
### Is it a bugfix ?
- Yes, according to the documentation onScrollBeginDrag is called when animation begins after letting up. But that is not the case, or am I missing something?

### Is it a new feature ?
- Yes
- Added support for onScrollEndDrag

### Describe what you've done:
- I have added support for onScrollEndDrag prop. As of today, there is no way to know when the swiper are going to animate to the next screen (when using gestures). On iOS onScrollEndDrag comes with targetContentOffset, which is very helpful.

### How to test it ?
`<Swiper ... onScrollEndDrag={({ nativeEvent }, state, context) => {
  console.log(nativeEvent, state, context)
}` />