### PR TITLE
New feature, add renderStickyContent child prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ AppRegistry.registerComponent('myproject', () => Swiper);
 | Prop  | Default  | Type | Description |
 | :------------ |:---------------:| :---------------:| :-----|
 | style | {...} | `style` | Custom styles will merge with the default styles. |
-| title | {<Text numberOfLines={1}>...</Text>} | `element` | If this parameter is not specified, will not render the title. |
+| title | {<Text numberOfLines={1}>...</Text>} | `element` | If this parameter is not specified, will not render the title. (Deprecated in favor of renderStickyContent) |
+| renderStickyContent | null | `function` | This parameter allow you to render sticky content over the slider. |
 
 #### Basic props of `<ScrollView />`
 

--- a/src/index.js
+++ b/src/index.js
@@ -560,11 +560,19 @@ export default class extends Component {
   renderTitle = () => {
     const child = this.props.children[this.state.index]
     const title = child && child.props && child.props.title
+
+    console.warn('Deprecated: Please now use renderStickyContent instead of title prop')
     return title
       ? (<View style={styles.title}>
         {this.props.children[this.state.index].props.title}
       </View>)
       : null
+  }
+
+  renderStickyContent = () => {
+    const child = this.props.children[this.state.index]
+    const renderStickyContent = child && child.props && child.props.renderStickyContent
+    return renderStickyContent ? renderStickyContent() : null
   }
 
   renderNextButton = () => {
@@ -721,6 +729,7 @@ export default class extends Component {
           ? renderPagination(index, total, this)
           : this.renderPagination())}
         {this.renderTitle()}
+        {this.renderStickyContent()}
         {showsButtons && this.renderButtons()}
       </View>
     )


### PR DESCRIPTION
### Describe what you've done:
 I just add a new child prop called `renderStickyContent`, this one allow user to print something above the slider for each screen specifically.
`title` child prop can now be deprecated in favour of this one that is more customisable.

### How to test it ?
Just add a prop `renderStickyContent` on your child and pass a component through a function.