### PR TITLE
Add undefined check for updateIndex (fixes #583)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -392,6 +392,7 @@ export default class extends Component {
    * @param  {string} dir    'x' || 'y'
    */
   updateIndex = (offset, dir, cb) => {
+    if (typeof offset === 'undefined' || typeof this.internals.offset === 'undefined') return
     const state = this.state
     let index = state.index
     if (!this.internals.offset)   // Android not setting this onLayout first? https://github.com/leecade/react-native-swiper/issues/582


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- fixes #583

### Is it a new feature ?
- No

### Describe what you've done:
Implemented an undefined check in the beginning of updateIndex, as outlined in [(comment #583)](https://github.com/leecade/react-native-swiper/issues/583#issuecomment-358508475). The code provided in the comment was first modified to be consistent with the package maintainer's code style.

### How to test it ?
By running the ```scrollBy``` function directly after a state change that causes the swiper to rerender. Without this fix, an error is thrown. However, the line added in this PR removes the error while still maintaining the expected functionality.
