### PR TITLE
Add containerStyle to typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,8 @@ declare module 'react-native-swiper' {
         height?: number
         // See default style in source.
         style?: ViewStyle
+        // See default container style in source.
+        containerStyle?: ViewStyle
         // Only load current index slide , loadMinimalSize slides before and after.
         loadMinimal?: boolean
         // see loadMinimal


### PR DESCRIPTION
Fixes gh-878

### Is it a bugfix ?
- No

### Is it a new feature ?
- No

### Describe what you've done:
Added the new `containerStyle` prop to the typescript declaration file.

### How to test it ?
Typescript linters should be happy again when using this prop.
