### PR TITLE
Remove ViewPagerAndroid, use ScrollView for all Platform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -463,11 +463,7 @@ export default class extends Component {
     if (state.dir === 'x') x = diff * state.width
     if (state.dir === 'y') y = diff * state.height
 
-    if (Platform.OS !== 'ios') {
-      this.scrollView && this.scrollView[animated ? 'setPage' : 'setPageWithoutAnimation'](diff)
-    } else {
-      this.scrollView && this.scrollView.scrollTo({ x, y, animated })
-    }
+    this.scrollView && this.scrollView.scrollTo({ x, y, animated })
 
     // update scroll state
     this.internals.isScrolling = true
@@ -633,32 +629,19 @@ export default class extends Component {
   }
 
   renderScrollView = pages => {
-    if (Platform.OS === 'ios') {
-      return (
-        <ScrollView ref={this.refScrollView}
-          {...this.props}
-          {...this.scrollViewPropOverrides()}
-          contentContainerStyle={[styles.wrapperIOS, this.props.style]}
-          contentOffset={this.state.offset}
-          onScrollBeginDrag={this.onScrollBegin}
-          onMomentumScrollEnd={this.onScrollEnd}
-          onScrollEndDrag={this.onScrollEndDrag}
-          style={this.props.scrollViewStyle}>
-          {pages}
-        </ScrollView>
-       )
-    }
     return (
-      <ViewPagerAndroid ref={this.refScrollView}
+      <ScrollView ref={this.refScrollView}
         {...this.props}
-        initialPage={this.props.loop ? this.state.index + 1 : this.state.index}
-        onPageScrollStateChanged={this.onPageScrollStateChanged}
-        onPageSelected={this.onScrollEnd}
-        key={pages.length}
-        style={[styles.wrapperAndroid, this.props.style]}>
+        {...this.scrollViewPropOverrides()}
+        contentContainerStyle={[styles.wrapperIOS, this.props.style]}
+        contentOffset={this.state.offset}
+        onScrollBeginDrag={this.onScrollBegin}
+        onMomentumScrollEnd={this.onScrollEnd}
+        onScrollEndDrag={this.onScrollEndDrag}
+        style={this.props.scrollViewStyle}>
         {pages}
-      </ViewPagerAndroid>
-    )
+      </ScrollView>
+     )
   }
 
   /**


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- Fixes #675, which rooted from ViewPagerAndroid attachment issue [#13463](https://github.com/facebook/react-native/issues/13463). This issue occurs when Swiper is inside attachable component, like Modal

### Is it a new feature ?
No.
- Include documentation, demo GIF if applicable

### Describe what you've done:
Removing platform checking and use same component for both platform in `renderScrollView` method. Previously: 
```
    if (Platform.OS === 'ios') {
      return (
        <ScrollView />
       )
    }
    return (
      <ViewPagerAndroid />
    )
```

Now only
```
    return (
      <ViewPagerAndroid />
    )
```

### How to test it ?
Wrap Swiper inside a modal, and run in **android**
```
<Modal
   {...properModalProps}
   >
   <Swiper>
       <Text>Your</Text>
       <Text>Content</Text>
       <Text>Here</Text>
   </Swiper>
</Modal>
```
And try to close and open the modal, it will sometimes show blank, sometimes not.



### Note
This is actually the same fix with #778 , however since that PR is not updated anymore (there's some left discussion that's not fixed yet in the PR), so I try to fix it and raise this PR.
