### PR TITLE
Add useViewPager prop to disable usage of ViewPagerAndroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > Hi there:
 
-[**头条财经前端团队急招**] 了解团队 / 投简历请联系: 
+[**头条财经前端团队急招**] 了解团队 / 投简历请联系:
 
 微信: 103024979 / 邮箱: leecade@163.com
 
@@ -39,7 +39,7 @@
 - **[1.5.6]**
   + Fix [#16](https://github.com/leecade/react-native-swiper/issues/16), [#36](https://github.com/leecade/react-native-swiper/issues/36), [#371](https://github.com/leecade/react-native-swiper/issues/371), [#410](https://github.com/leecade/react-native-swiper/issues/410), [#411](https://github.com/leecade/react-native-swiper/issues/411), [#422](https://github.com/leecade/react-native-swiper/issues/422), [#468](https://github.com/leecade/react-native-swiper/issues/468) Fix landscape orientation auto resize! (thanks [@ahmed3mar](https://github.com/ahmed3mar), [@timmywil](https://github.com/timmywil))
   + Add containerStyle prop to customize the view container.
-  
+
 - [1.5.5]
   + Update: using PropTypes from prop-types and Change View.propTypes to ViewPropTypes
 
@@ -259,6 +259,7 @@ AppRegistry.registerComponent('myproject', () => Swiper);
 | removeClippedSubviews | true | `bool` | If true, offscreen child views (whose overflow value is hidden) are removed from their native backing superview when offscreen. This canimprove scrolling performance on long lists.  |
 | automaticallyAdjustContentInsets | false | `bool` | Set to `true` if you need adjust content insets automation. |
 | scrollEnabled | true | `bool` | Enables/Disables swiping |
+| useViewPager | true | `bool` | Enables/Disables the use of `ViewPagerAndroid` component on Android in favour of `ScrollView` |
 
 > @see: http://facebook.github.io/react-native/docs/scrollview.html
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ export default class extends Component {
     activeDotStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     dotColor: PropTypes.string,
     activeDotColor: PropTypes.string,
+    useViewPager: PropTypes.bool,
     /**
      * Called when the index has changed because the user swiped.
      */
@@ -170,6 +171,7 @@ export default class extends Component {
     autoplayTimeout: 2.5,
     autoplayDirection: true,
     index: 0,
+    useViewPager: true,
     onIndexChanged: () => null
   }
 
@@ -463,7 +465,7 @@ export default class extends Component {
     if (state.dir === 'x') x = diff * state.width
     if (state.dir === 'y') y = diff * state.height
 
-    if (Platform.OS !== 'ios') {
+    if (Platform.OS !== 'ios' && this.props.useViewPager) {
       this.scrollView && this.scrollView[animated ? 'setPage' : 'setPageWithoutAnimation'](diff)
     } else {
       this.scrollView && this.scrollView.scrollTo({ x, y, animated })
@@ -633,7 +635,7 @@ export default class extends Component {
   }
 
   renderScrollView = pages => {
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'ios' || !this.props.useViewPager) {
       return (
         <ScrollView ref={this.refScrollView}
           {...this.props}


### PR DESCRIPTION
### Is it a bugfix ?
- No

### Is it a new feature ?
- Yes

### Describe what you've done:
Adds a new `useViewPager` prop to use `ScrollView` component instead of `ViewPagerAndroid` on Android devices.

### How to test it ?
Set the prop to false and test it on an Android device
