### PR TITLE
react-native-swiper can be used on web

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ export default class extends Component {
     // related to https://github.com/leecade/react-native-swiper/issues/570
     // contentOffset is not working in react 0.48.x so we need to use scrollTo
     // to emulate offset.
-    if (Platform.OS === 'ios') {
+    if (Platform.OS !== 'android') {
       if (this.initialRender && this.state.total > 1) {
         this.scrollView.scrollTo({...offset, animated: false})
         this.initialRender = false;
@@ -424,7 +424,7 @@ export default class extends Component {
     newState.index = index
     newState.loopJump = loopJump
 
-    this.internals.offset = offset
+    this.internals.offset = {...offset}
 
     // only update offset in state if loopJump is true
     if (loopJump) {
@@ -463,7 +463,7 @@ export default class extends Component {
     if (state.dir === 'x') x = diff * state.width
     if (state.dir === 'y') y = diff * state.height
 
-    if (Platform.OS !== 'ios') {
+    if (Platform.OS === 'android') {
       this.scrollView && this.scrollView[animated ? 'setPage' : 'setPageWithoutAnimation'](diff)
     } else {
       this.scrollView && this.scrollView.scrollTo({ x, y, animated })
@@ -633,7 +633,7 @@ export default class extends Component {
   }
 
   renderScrollView = pages => {
-    if (Platform.OS === 'ios') {
+    if (Platform.OS !== 'android') {
       return (
         <ScrollView ref={this.refScrollView}
           {...this.props}


### PR DESCRIPTION
 if and when https://github.com/necolas/react-native-web/pull/1091 will be merged

### Is it a bugfix ?
- Not completely fix #455 ... Waiting for merging PR on react-native-web repo

Plus a little fix: Objects are assigned by ref. [This assignment](https://github.com/leecade/react-native-swiper/blob/master/src/index.js#L427) must be as object copy

### Is it a new feature ?
- May be if RN-web will merge