### PR TITLE
Fix flow error

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -1,8 +1,5 @@
 // @flow strict
 
-// eslint-disable-next-line
-import type { Component, Node } from 'react';
-
 declare module 'react-native-swiper' {
   // eslint-disable-next-line no-undef
   declare export type SwiperProps = $ReadOnly<{|
@@ -40,11 +37,11 @@ declare module 'react-native-swiper' {
     // Custom styles will merge with the default styles.
     paginationStyle?: ?Object,
     // Complete control how to render pagination with three params (index, total, context) ref to this.state.index / this.state.total / this, For example: show numbers instead of dots.
-    renderPagination?: ?(index: number, total: number, context: any) => Node,
+    renderPagination?: ?(index: number, total: number, context: any) => React$Node,
     // Allow custom the dot element.
-    dot?: ?Node,
+    dot?: ?React$Node,
     // Allow custom the active-dot element.
-    activeDot?: ?Node,
+    activeDot?: ?React$Node,
     // Allow custom the active-dot element.
     dotStyle?: ?Object,
     // Allow custom the active-dot element.
@@ -64,9 +61,9 @@ declare module 'react-native-swiper' {
     // Set to true make control buttons visible.
     buttonWrapperStyle?: ?Object,
     // Allow custom the next button.
-    nextButton?: ?Node,
+    nextButton?: ?React$Node,
     // Allow custom the prev button.
-    prevButton?: ?Node,
+    prevButton?: ?React$Node,
 
     // Supported ScrollResponder
     // When animation begins after letting up
@@ -105,7 +102,7 @@ declare module 'react-native-swiper' {
   |}>;
 
   // eslint-disable-next-line no-undef
-  declare export default class Swiper extends Component<SwiperProps> {
+  declare export default class Swiper extends React$Component<SwiperProps> {
     scrollBy(index: number, animated?: boolean): void;
   }
 }


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- without issue

### Is it a new feature ?
- No

### Describe what you've done:
To fix this error, I remove the import declaration and use flow.js react definition
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-swiper/index.js.flow:108:47

Cannot reference type Component [1] from a value position.

 [1]   4│ import type { Component, Node } from 'react';
        :
     105│   |}>;
     106│
     107│   // eslint-disable-next-line no-undef
     108│   declare export default class Swiper extends Component<SwiperProps> {
     109│     scrollBy(index: number, animated?: boolean): void;
     110│   }
     111│ }
```


### How to test it?
```sh
create-react-native testApp;
cd testApp; yarn;
flow init;
yarn add react-native-swiper;
# in `index.js` add `import Swiper from 'react-native-swiper';`
npx flow;
```