### PR TITLE
Add null return type for renderPagination prop.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module 'react-native-swiper' {
         // Custom styles will merge with the default styles.
         paginationStyle?: ViewStyle
         // Complete control how to render pagination with three params (index, total, context) ref to this.state.index / this.state.total / this, For example: show numbers instead of dots.
-        renderPagination?: (index: number, total: number, swiper: Swiper) => JSX.Element
+        renderPagination?: (index: number, total: number, swiper: Swiper) => JSX.Element | null
         // Allow custom the dot element.
         dot?: any
         // Allow custom the active-dot element.


### PR DESCRIPTION
Convert return type for renderPagination to a union type of JSX.Element and null. This allows users to pass custom pagination that sometimes returns null. It is in accordance with the usage src/index.js, which has a renderPagination method that returns null if total <= 1.

### Is it a bugfix ?
- No

### Is it a new feature ?
- No

### Describe what you've done:
Add union return type to prop renderPagination. 

`renderPagination?: (index: number, total: number, swiper: Swiper) => JSX.Element | null // was JSX.Element`

### How to test it ?
Make the change. Then, the warning from linter should disappear. 
