### PR TITLE
Fix offset undefined error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -394,6 +394,7 @@ export default class extends Component {
   updateIndex = (offset, dir, cb) => {
     const state = this.state
     let index = state.index
+    if(offset === undefined || this.internals.offset === undefined){ return; }
     if (!this.internals.offset)   // Android not setting this onLayout first? https://github.com/leecade/react-native-swiper/issues/582
       this.internals.offset = {}
     const diff = offset[dir] - this.internals.offset[dir]

--- a/src/index.js
+++ b/src/index.js
@@ -394,7 +394,9 @@ export default class extends Component {
   updateIndex = (offset, dir, cb) => {
     const state = this.state
     let index = state.index
-    if(offset === undefined || this.internals.offset === undefined){ return; }
+    if (offset === undefined || this.internals.offset === undefined) {
+      return;
+    }
     if (!this.internals.offset)   // Android not setting this onLayout first? https://github.com/leecade/react-native-swiper/issues/582
       this.internals.offset = {}
     const diff = offset[dir] - this.internals.offset[dir]


### PR DESCRIPTION
### Is it a bugfix ?
- Yes https://github.com/leecade/react-native-swiper/issues/583#issuecomment-358508475

### Is it a new feature ?
- No

### Describe what you've done:
Adding the check that offset exist, like in the related comment:
`if(offset === undefined || this.internals.offset === undefined){ return; }`

### How to test it ?
Test on slower android devices (we get this error from sentry).