### PR TITLE
update to use new React Native or RN >=0.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "updtr": "^2.0.0"
   },
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "@react-native-community/viewpager": "^1.1.7",
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,10 @@ import {
   ScrollView,
   Dimensions,
   TouchableOpacity,
-  ViewPagerAndroid,
   Platform,
   ActivityIndicator
-} from 'react-native'
+} from 'react-native';
+import ViewPagerAndroid from "@react-native-community/viewpager";
 
 /**
  * Default styles


### PR DESCRIPTION
update to use new React Native or RN >=0.59

### Is it a bugfix ?
No

### Is it a new feature ?
Yes is a update lib

> Deprecated. Use react-native-community/react-native-viewpager instead.
[link](https://facebook.github.io/react-native/docs/0.59/viewpagerandroid)

### Describe what you've done:
add dependence and lib

### How to test it ?
same older