### PR TITLE
fix(autoplay): replay when autoplay is setted to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "react-native",
     "ios"
   ],
-  "version": "1.6.0-dev",
+  "version": "1.6.0-nightly.1",
   "description": "Swiper component for React Native.",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -208,6 +208,13 @@ export default class extends Component {
       this.props.onIndexChanged(nextState.index)
   }
 
+  componentDidUpdate(prevProps) {
+    // If autoplay props updated to true, autoplay immediately
+    if (this.props.autoplay && !prevProps.autoplay) {
+      this.autoplay()
+    }
+  }
+
   initState(props, updateIndex = false) {
     // set the current state
     const state = this.state || { width: 0, height: 0, offset: { x: 0, y: 0 } }
@@ -511,7 +518,12 @@ export default class extends Component {
    */
 
   scrollTo = (index, animated = true) => {
-    if (this.internals.isScrolling || this.state.total < 2 || index == this.state.index) return
+    if (
+      this.internals.isScrolling ||
+      this.state.total < 2 ||
+      index == this.state.index
+    )
+      return
 
     const state = this.state
     const diff = this.state.index + (index - this.state.index)
@@ -522,7 +534,8 @@ export default class extends Component {
     if (state.dir === 'y') y = diff * state.height
 
     if (Platform.OS !== 'ios') {
-      this.scrollView && this.scrollView[animated ? 'setPage' : 'setPageWithoutAnimation'](diff)
+      this.scrollView &&
+        this.scrollView[animated ? 'setPage' : 'setPageWithoutAnimation'](diff)
     } else {
       this.scrollView && this.scrollView.scrollTo({ x, y, animated })
     }


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- fix #989

### Is it a new feature ?
- No

### Describe what you've done:

continue to play when this.props.autoplay is setted to true

### How to test it ?

```tsx
const SwiperComponent = () => {
  const [autoPlay, setAutoPlay] = useState(true)
  return (
    <Swiper style={styles.wrapper} autoplay={autoPlay}>
      <View style={styles.slide1}>
        <TouchableWithoutFeedback onPress={() => setAutoPlay(false)}>
          <Text style={styles.text}>Stop</Text>
        </TouchableWithoutFeedback>
      </View>
      <View style={styles.slide2}>
        <Text style={styles.text}>HHH</Text>
      </View>
      <View style={styles.slide3}>
        <TouchableWithoutFeedback onPress={() => setAutoPlay(true)}>
          <Text style={styles.text}>Start</Text>
        </TouchableWithoutFeedback>
      </View>
    </Swiper>
  )
}
```

autoPlay: true => false => true
