### PR TITLE
Add missing scrollTo TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,7 @@ declare module 'react-native-swiper' {
   }
 
   export default class Swiper extends Component<SwiperProps> {
-    scrollBy: (index?: number, animated?: boolean) => void
+    scrollBy: (index?: number, animated?: boolean) => void;
+    scrollTo: (index: number, animated?: boolean) => void;
   }
 }


### PR DESCRIPTION
### Is it a bugfix ?
- Yes, issue #1035 

### Is it a new feature ?
- No

### Describe what you've done:
Added a TypeScript definition for `scrollTo` to `index.d.ts`

### How to test it ?
```
import Swiper from 'react-native-swiper'

const swiper: Swiper = new Swiper({})
if (swiper) {
  swiper.scrollTo(1, false)
}
```
This will now pass the TypeScript compiler whereas before it wouldn't
