### PR TITLE
Add pages handler with next and prev actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ AppRegistry.registerComponent('myproject', () => SwiperComponent)
 | buttonWrapperStyle | `{backgroundColor: 'transparent', flexDirection: 'row', position: 'absolute', top: 0, left: 0, flex: 1, paddingHorizontal: 10, paddingVertical: 10, justifyContent: 'space-between', alignItems: 'center'}` |  `style`  | Custom styles.                              |
 | nextButton         |                                                                                 `<Text style={styles.buttonText}>›</Text>`                                                                                  | `element` | Allow custom the next button.               |
 | prevButton         |                                                                                 `<Text style={styles.buttonText}>‹</Text>`                                                                                  | `element` | Allow custom the prev button.               |
+| refPages           |                                                                                 -                                                                                                                              | `function` | Pages handler to next or prev action.      |
 
 #### Props of Children
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,8 @@ declare module 'react-native-swiper' {
     style?: StyleProp<ViewStyle>
     // Customize the View container.
     containerStyle?: StyleProp<ViewStyle>
+    // Customize the ScrollView container.
+    scrollViewStyle?: StyleProp<ViewStyle>
     // Only load current index slide , loadMinimalSize slides before and after.
     loadMinimal?: boolean
     // see loadMinimal

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,8 @@ declare module 'react-native-swiper' {
     nextButton?: React.ReactNode
     // Allow custom the prev button.
     prevButton?: React.ReactNode
+    // Reference to handle page actions
+    refPages?: (ref: object) => { next?: () => void; prev?: () => void }
 
     // Supported ScrollResponder
     // When animation begins after letting up

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,7 @@ export default class extends Component {
     ]),
     dotColor: PropTypes.string,
     activeDotColor: PropTypes.string,
+    refPages: PropTypes.func,
     /**
      * Called when the index has changed because the user swiped.
      */
@@ -174,7 +175,8 @@ export default class extends Component {
     autoplayTimeout: 2.5,
     autoplayDirection: true,
     index: 0,
-    onIndexChanged: () => null
+    onIndexChanged: () => null,
+    refPages: () => null
   }
 
   /**
@@ -207,6 +209,7 @@ export default class extends Component {
 
   componentDidMount() {
     this.autoplay()
+    this.props.refPages({ next: () => this.nextPage(), prev: () => this.prevPage() })
   }
 
   componentWillUnmount() {
@@ -704,10 +707,27 @@ export default class extends Component {
     ) : null
   }
 
+  allowNextPage = () =>
+    this.props.loop || this.state.index !== this.state.total - 1
+
+  allowPrevPage = () => this.props.loop || this.state.index !== 0
+
+  nextPage = () => {
+    if (this.allowNextPage()) {
+      return this.scrollBy(1)
+    }
+  }
+
+  prevPage = () => {
+    if (this.allowPrevPage()) {
+      return this.scrollBy(-1)
+    }
+  }
+
   renderNextButton = () => {
     let button = null
 
-    if (this.props.loop || this.state.index !== this.state.total - 1) {
+    if (this.allowNextPage()) {
       button = this.props.nextButton || <Text style={styles.buttonText}>›</Text>
     }
 
@@ -724,7 +744,7 @@ export default class extends Component {
   renderPrevButton = () => {
     let button = null
 
-    if (this.props.loop || this.state.index !== 0) {
+    if (this.allowPrevPage()) {
       button = this.props.prevButton || <Text style={styles.buttonText}>‹</Text>
     }
 


### PR DESCRIPTION
### Is it a bugfix ?
- No

### Is it a new feature ?
- Yes
- Include documentation

### Describe what you've done:
Allow use next and prev action out component

### How to test it ?
Use prop:
refPages={ref => this.ref = ref}

Use (for example) a button outside component
<Button onPress={() => this.ref.next()}
