### PR TITLE
Pass State Types to Swiper Component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,7 +138,7 @@ declare module 'react-native-swiper' {
     scrollEnabled?: boolean
   }
 
-  export default class Swiper extends Component<SwiperProps> {
+  export default class Swiper extends Component<SwiperProps, SwiperStates> {
     scrollBy: (index?: number, animated?: boolean) => void;
     scrollTo: (index: number, animated?: boolean) => void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ import {
 import { Component } from 'react'
 
 declare module 'react-native-swiper' {
-  interface SwiperStates {
+  interface SwiperState {
     autoplayEnd: false
     loopJump: false
     width: number
@@ -21,7 +21,7 @@ declare module 'react-native-swiper' {
     dir: 'x' | 'y'
   }
 
-  interface SwiperInternals extends SwiperStates {
+  interface SwiperInternals extends SwiperState {
     isScrolling: boolean
   }
 
@@ -138,7 +138,7 @@ declare module 'react-native-swiper' {
     scrollEnabled?: boolean
   }
 
-  export default class Swiper extends Component<SwiperProps, SwiperStates> {
+  export default class Swiper extends Component<SwiperProps, SwiperState> {
     scrollBy: (index?: number, animated?: boolean) => void;
     scrollTo: (index: number, animated?: boolean) => void;
   }


### PR DESCRIPTION
### Is it a bugfix ?
- Yes or No ? No
- If yes, which issue (fix #number) ? I didn't see an open issue for this

### Is it a new feature ?
- Yes or no ? No (I don't think so)
- Include documentation, demo GIF if applicable

### Describe what you've done:
In trying to do something along the lines of:

```tsx
  const swiper = React.useRef<ReactNativeSwiper>(null);
  
  React.useEffect(() => {
      if (!swiper.current) {
        return;
      }
      if (swiper.current.state.index !== indexOfNextQuestion) {
        swiper.current.scrollBy(
          indexOfNextQuestion - swiper.current.state.index,
          true
        );
  }
```

TypeScript was saying "Property 'index' does not exist on type 'Readonly<{}>'." on `swiper.current.state.index`, even though the value was defined at runtime and these values appeared to be defined in state in the component's source code. 

In looking at the types, it looked like the state wasn't being passed to the `React.Component` type, so it made sense that TS believed that the state object was empty. Applying this change resolves that.

### How to test it ?
I've tested it in my project. I imagine anything that tries to pull state off of a ref will encounter this issue. Happy to try to put together a quick test project if that would be useful.

Thank you for your work on this project, please let me know if I there's anything I can do to improve this PR!