### PR TITLE
Using initState.index instead of props.index in initState() to set th…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,8 +283,13 @@ export default class extends Component {
       initState.height = height
     }
 
+    let offsetIndex = initState.index;
+
+    if (this.props.loop) {
+      offsetIndex++;
+    }
     initState.offset[initState.dir] =
-      initState.dir === 'y' ? height * props.index : width * props.index
+      initState.dir === "y" ? height * offsetIndex : width * offsetIndex;
 
     this.internals = {
       ...this.internals,


### PR DESCRIPTION
Using initState.index instead of props.index in initState() to set the new current offset, as well as offsetting the index by 1 if this.props.loop is set to true.

### Is it a bugfix ?
- Yes #1078

### Is it a new feature ?
- no

### Describe what you've done:
Using initState.index instead of props.index in initState() to set the new current offset
Also offsetting the index by 1 if this.props.loop is set to true.
The reason for the index offset is that the index would not be the same in a looping carousel vs not, this matches the logic used in onLayout
