### PR TITLE
Fix content offset value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ export default class extends Component {
         {...this.props}
         {...this.scrollViewPropOverrides()}
         contentContainerStyle={[styles.wrapperIOS, this.props.style]}
-        contentOffset={this.state.offset}
+        contentOffset={this.fullState().offset}
         onScrollBeginDrag={this.onScrollBegin}
         onMomentumScrollEnd={this.onScrollEnd}
         onScrollEndDrag={this.onScrollEndDrag}


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- https://github.com/leecade/react-native-swiper/issues/1053

### Describe what you've done:
The contentOffset was looking inside state rather than this.internals, where the offset is adjusted. This means as soon as setState is called the offset resets. 

### How to test it ?
Create a swiper with 2 slides, swipe to slide 2 and then trigger a setState.