### PR TITLE
Add skip initial render prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ AppRegistry.registerComponent('myproject', () => SwiperComponent)
 | style             |          {...}          |  `style`  | See default style in source.                                               |
 | containerStyle    |          {...}          |  `style`  | See default container style in source.                                     |
 | loadMinimal       |          false          |  `bool`   | Only load current index slide , `loadMinimalSize` slides before and after. |
+| skipInitialRender |          false          |  `bool`   | Prevents rendering slides until onLayout completes to prevent flickering.  |
 | loadMinimalSize   |            1            | `number`  | see `loadMinimal`                                                          |
 | loadMinimalLoader | `<ActivityIndicator />` | `element` | Custom loader to display when slides aren't loaded                         |
 

--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ export default class extends Component {
         {...this.props}
         {...this.scrollViewPropOverrides()}
         contentContainerStyle={[styles.wrapperIOS, this.props.style]}
-        contentOffset={this.state.offset}
+        contentOffset={this.fullState().offset}
         onScrollBeginDrag={this.onScrollBegin}
         onMomentumScrollEnd={this.onScrollEnd}
         onScrollEndDrag={this.onScrollEndDrag}

--- a/src/index.js
+++ b/src/index.js
@@ -780,7 +780,7 @@ export default class extends Component {
         {...this.props}
         {...this.scrollViewPropOverrides()}
         contentContainerStyle={[styles.wrapperIOS, this.props.style]}
-        contentOffset={this.fullState().offset}
+        contentOffset={this.state.offset}
         onScrollBeginDrag={this.onScrollBegin}
         onMomentumScrollEnd={this.onScrollEnd}
         onScrollEndDrag={this.onScrollEndDrag}

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ export default class extends Component {
     scrollsToTop: PropTypes.bool,
     removeClippedSubviews: PropTypes.bool,
     automaticallyAdjustContentInsets: PropTypes.bool,
+    skipInitialRender: PropTypes.bool,
     showsPagination: PropTypes.bool,
     showsButtons: PropTypes.bool,
     disableNextButton: PropTypes.bool,
@@ -804,6 +805,7 @@ export default class extends Component {
       loadMinimalLoader,
       renderPagination,
       showsButtons,
+      skipInitialRender,
       showsPagination
     } = this.props
     // let dir = state.dir
@@ -821,7 +823,11 @@ export default class extends Component {
     }
 
     // For make infinite at least total > 1
-    if (total > 1) {
+    if (this.initialRender && skipInitialRender) {
+      pages = (
+        <View style={pageStyle} key={0}/>
+      )
+    } else if (total > 1) {
       // Re-design a loop model for avoid img flickering
       pages = Object.keys(children)
       if (loop) {


### PR DESCRIPTION
### Is it a bugfix ?
- Yes

### Describe what you've done:
When rendering within a SafeAreaView, there is a clear height change once onLayout is called. To prevent this flickering, this adds the ability to skip rendering content until onLayout has finished.

### How to test it ?
Create a swiper within a SafeAreaView (or probably just a view with flex:1), watch the pagination jump.