### PR TITLE
scroll to new position if swipe container size chages (ex: orientatio…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -321,8 +321,11 @@ export default class extends Component {
     // related to https://github.com/leecade/react-native-swiper/issues/570
     // contentOffset is not working in react 0.48.x so we need to use scrollTo
     // to emulate offset.
-    if (this.initialRender && this.state.total > 1) {
+    if(this.state.total > 1) {
       this.scrollView.scrollTo({ ...offset, animated: false })
+    }
+	
+    if (this.initialRender) {
       this.initialRender = false
     }
 


### PR DESCRIPTION
The scrollTo method should not be called only on initial render. onLayout invoke can be caused by an orientation change or swipe container resize. So whenever we have got slides inside we should consider to call scrollTo

### Is it a bugfix ?
Yes (No ticket # yet)
Bug can be tested on Android tablet (Galaxy tab A). Just make a fullscreen swiper fill with some colored boxes and move to a slideindex more then 0. Then change the orientation. The slider will stack in between 2 slides and not adjust it's scroll position.

### Is it a new feature ?
No

### Describe what you've done:
Just moved the scrollTo method outside the initialRender method. I think there is no need for the initialRender flag anymore

### How to test it ?
See Bugfix