### PR TITLE
apply prefix UNSAFE_ to suppress warning for componentWillReceiveProps and componentWillUpdate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,7 @@ export default class extends Component {
   autoplayTimer = null
   loopJumpTimer = null
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!nextProps.autoplay && this.autoplayTimer)
       clearTimeout(this.autoplayTimer)
     if (nextProps.index === this.props.index) return
@@ -214,7 +214,7 @@ export default class extends Component {
     this.loopJumpTimer && clearTimeout(this.loopJumpTimer)
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  UNSAFE_componentWillUpdate(nextProps, nextState) {
     // If the index has changed, we notify the parent via the onIndexChanged callback
     if (this.state.index !== nextState.index)
       this.props.onIndexChanged(nextState.index)


### PR DESCRIPTION
### Is it a bugfix ?
- Yes 
- If yes, which issue (fix #number) ? 
   - [#1034 ]

### Is it a new feature ?
- No

### Describe what you've done:
Added prefix `UNSAFE_` to the method `componentWillReceiveProps` and `componentWillUpdate`

### How to test it ?
Render a Swiper component
