### PR TITLE
fix issue #1171 - slide alignment issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ export default class extends Component {
     }
 
     initState.offset[initState.dir] =
-      initState.dir === 'y' ? height * props.index : width * props.index
+      initState.dir === 'y' ? initState.height * props.index : initState.width * props.index
 
     this.internals = {
       ...this.internals,


### PR DESCRIPTION
Fix issue #1171 and maybe more

Slider doesn't calculate offsets correctly when slider isn't full screen because when componentDidUpdate is called and updates the state based on an initState call it uses the return from Dimensions.get('window') instead of the value from props if there is one. The value that should be used is calculated just before the incorrect value is used.

Bug was evident if you created a slider with a height and width different to the values of Dimensions.get('window'). On initial render it displayed correctly but on swiping you would end up with offsets depending on the difference between props.height/props.width and the values coming from Dimensions.get('window')

This fixes that 
