### PR TITLE
Fix React type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -143,4 +143,5 @@ declare module 'react-native-swiper' {
   export default class Swiper extends Component<SwiperProps, SwiperState> {
     scrollBy: (index?: number, animated?: boolean) => void
     scrollTo: (index: number, animated?: boolean) => void
+  }
 }


### PR DESCRIPTION
### Is it a bugfix ?
Yes

### Is it a new feature ?
No

### Describe what you've done:
Fixed mistakenly removed `}` whose absence caused
```
This missing `}` caused cause TypeScript error:
`node_modules/react-native-swiper/index.d.ts:147:1 - error TS1005: '}' expected.
```

### How to test it ?
Use in React and run Typescript compilation.
