### PR TITLE
:bug: Fixed issue IOS not fire onIndexChanged

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -464,7 +464,7 @@ export default class extends Component {
     if (!this.internals.offset)
       // Android not setting this onLayout first? https://github.com/leecade/react-native-swiper/issues/582
       this.internals.offset = {}
-    const diff = offset[dir] - this.internals.offset[dir]
+    const diff = offset[dir] - (this.internals.offset[dir] ? this.internals.offset[dir] : 0)
     const step = dir === 'x' ? state.width : state.height
     let loopJump = false
 


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- fix [#1141](https://github.com/leecade/react-native-swiper/issues/1141)

### Describe what you've done:
Sometimes the `this.internals.offset[dir]` was `undefined` and this broke the `diff` value and make it index was `NaN`, hence that not fires `onIndexChanged` function.

### How to test it ?
Try use latest version of lib on IOS emulator adding a log function `onIndexChanged`, sometimes that function is not fires.
