### PR TITLE
fix NaN on mount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -464,7 +464,7 @@ export default class extends Component {
     if (!this.internals.offset)
       // Android not setting this onLayout first? https://github.com/leecade/react-native-swiper/issues/582
       this.internals.offset = {}
-    const diff = offset[dir] - this.internals.offset[dir]
+    const diff = offset[dir] - (this.internals.offset[dir] || 0)
     const step = dir === 'x' ? state.width : state.height
     let loopJump = false
 


### PR DESCRIPTION
### Is it a bugfix ?
- Yes or No ? Yes
- If yes, which issue (fix #number) ? #1192

### Is it a new feature ?
- Yes or no ? No
- Include documentation, demo GIF if applicable

### Describe what you've done:

Ensured that updateIndex does not result in a NaN when you scrollTo or scrollBy on mount

### How to test it ?
scrollTo or scrollBy on mount using a ref to the component
old version: nothing happens
new version: works