### PR TITLE
fixed scrollTo function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -563,8 +563,7 @@ export default class extends Component {
   scrollTo = (index, animated = true) => {
     if (
       this.internals.isScrolling ||
-      this.state.total < 2 ||
-      index == this.state.index
+      this.state.total < 2
     )
       return
 


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- It fixes #1213  ?

### Is it a new feature ?
- No

### Describe what you've done:

Deleted extra comparison in function body of scrollTo to avoid comparing wrong state index instead of real one.
`swiper.current.state.index` differs from real swiper index by one

### How to test it ?

Try to run issue example with that fix
