### PR TITLE
adding custom styles to button touchable opacity directly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -709,6 +709,7 @@ export default class extends Component {
 
     return (
       <TouchableOpacity
+	style={this.props.nextButtonStyle}
         onPress={() => button !== null && this.scrollBy(1)}
         disabled={this.props.disableNextButton}
       >
@@ -726,6 +727,7 @@ export default class extends Component {
 
     return (
       <TouchableOpacity
+	style={this.props.prevButtonStyle}
         onPress={() => button !== null && this.scrollBy(-1)}
         disabled={this.props.disablePrevButton}
       >

--- a/src/index.js
+++ b/src/index.js
@@ -709,7 +709,7 @@ export default class extends Component {
 
     return (
       <TouchableOpacity
-	style={this.props.nextButtonStyle}
+        style={this.props.nextButtonStyle}
         onPress={() => button !== null && this.scrollBy(1)}
         disabled={this.props.disableNextButton}
       >
@@ -727,7 +727,7 @@ export default class extends Component {
 
     return (
       <TouchableOpacity
-	style={this.props.prevButtonStyle}
+        style={this.props.prevButtonStyle}
         onPress={() => button !== null && this.scrollBy(-1)}
         disabled={this.props.disablePrevButton}
       >


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- If yes, which issue (fix #number) ?
     No fix # but I was having an issue where the button I wanted to add needed margin but if I were to add that margin to the button the white space containing the margin is still clickable, but if we are able to pass a style prop to the button directly it fixes this issue

### Is it a new feature ?
- Yes
- Include documentation, demo GIF if applicable
can try and produce if needed

### Describe what you've done:
I've simply introduced a new prop which adds styling to the button if wanted

### How to test it ?
Add style and see if it take place on the previous and next buttons
