### PR TITLE
fix update state warning in onIndexChanged

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,13 +214,11 @@ export default class extends Component {
     this.loopJumpTimer && clearTimeout(this.loopJumpTimer)
   }
 
-  UNSAFE_componentWillUpdate(nextProps, nextState) {
+  componentDidUpdate(prevProps, prevState) {
     // If the index has changed, we notify the parent via the onIndexChanged callback
-    if (this.state.index !== nextState.index)
-      this.props.onIndexChanged(nextState.index)
-  }
-
-  componentDidUpdate(prevProps) {
+    if (this.state.index !== prevState.index)
+      this.props.onIndexChanged(this.state.index)
+    
     // If autoplay props updated to true, autoplay immediately
     if (this.props.autoplay && !prevProps.autoplay) {
       this.autoplay()


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
- If yes, which issue? #1231

### Is it a new feature ?
- No 

### Describe what you've done:
Fixed the issue where a warning is displayed if the state of the parent component is updated in onIndexChanged with the useState hook.

### How to test it ?
Create a swiper with onIndexChanged callback that updates parent state with useState hook.

