### PR TITLE
Update react-native documentation address link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ export default class extends Component {
   /**
    * Default props
    * @return {object} props
-   * @see http://facebook.github.io/react-native/docs/scrollview.html
+   * @see https://reactnative.dev/docs/scrollview
    */
   static defaultProps = {
     horizontal: true,


### PR DESCRIPTION
http://facebook.github.io/react-native/docs/scrollview.html changed to https://reactnative.dev/docs/scrollview

### Is it a bugfix ?
- No

### Is it a new feature ?
- No

### Describe what you've done:
I've updated the link address to react-native ScrollView documantation.

### How to test it ?
Open the link in a browser like Chrome.
