### PR TITLE
fix initState calc the offset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,8 +283,12 @@ export default class extends Component {
       initState.height = height
     }
 
+    let offsetIndex = props.index
+    if (props.loop) {
+      offsetIndex += 1
+    }
     initState.offset[initState.dir] =
-      initState.dir === 'y' ? initState.height * props.index : initState.width * props.index
+      initState.dir === 'y' ? initState.height * offsetIndex : initState.width * offsetIndex
 
     this.internals = {
       ...this.internals,
@@ -324,7 +328,7 @@ export default class extends Component {
     if(this.state.total > 1) {
       this.scrollView.scrollTo({ ...offset, animated: false })
     }
-	
+
     if (this.initialRender) {
       this.initialRender = false
     }


### PR DESCRIPTION
I think you forget the the loop=true in initState calc the offset

The example:
```
import React, {useState} from 'react';
import {View, Text, Button} from 'react-native';
import Swiper from 'react-native-swiper';

export interface TestSwiperViewProps {}

var styles = {
  wrapper: {},
  slide1: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#9DD6EB',
  },
  slide2: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#97CAE5',
  },
  slide3: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#92BBD9',
  },
  text: {
    color: '#fff',
    fontSize: 30,
    fontWeight: 'bold',
  },
};

const TestSwiperView: React.FC<TestSwiperViewProps> = props => {
  const [imgs, setImgs] = useState(['1', '2', '3']);

  return (
    <View
      style={{
        height: '100%',
      }}>
      <Button
        title={'setState'}
        onPress={() => {
          setImgs([...imgs]);
        }}
      />
      <Swiper style={styles.wrapper} showsButtons={false} loop={false}>
        {imgs.map(img => {
          return (
            <View testID="Hello" style={styles.slide1}>
              <Text style={styles.text}>{img}</Text>
            </View>
          );
        })}
      </Swiper>
    </View>
  );
};

export default TestSwiperView;
```

Reproduce step:
1. scroll to page 2.
2. click the top button.