### PR TITLE
Issue where index is -1 or more than total

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -489,6 +489,14 @@ export default class extends Component {
         offset[dir] = step
         loopJump = true
       }
+    } else {
+      // Note: this is a hack to solve the overflow or underflow of index
+      // when user navigates to quickly
+      if (index <= -1) {
+        index = 0
+      } else if (index >= state.total) {
+        index = state.total - 1
+      }
     }
 
     const newState = {}


### PR DESCRIPTION
When the user does a crazy amount of swapping the component get diff as negative or positive and sometimes result in an overflow 'or' underflow of the index results in the component sort of not responding. This only reset the value to 0 or total if the loop is false

### Is it a bugfix ?
- Yes
- If yes, which issue - Sorry, no idea our QA reported this (and replicating it is almost impossible) and we figured out it was because the index was going to -1 in our case.

### Describe what you've done:
It just a minor check if not loop and index is negative or more than total then it reset them to the limit of 0 or total - 1 seeing that total is set to 1 if not passed or 0, this shouldn't cause a NaN

### How to test it?
Like a large number of users swipes left and right randomly (guess onScrollEnd to call with diff and x = 0) again only happens for a non-loop scenario.