### PR TITLE
add missing type to type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,8 @@ declare module 'react-native-swiper' {
     height?: number
     // See default style in source.
     style?: StyleProp<ViewStyle>
+    // Customize the ScrollView style
+    scrollViewStyle?: StyleProp<ViewStyle>,
     // Customize the View container.
     containerStyle?: StyleProp<ViewStyle>
     // Only load current index slide , loadMinimalSize slides before and after.

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,7 @@ declare module 'react-native-swiper' {
     // See default style in source.
     style?: StyleProp<ViewStyle>
     // Customize the ScrollView style
-    scrollViewStyle?: StyleProp<ViewStyle>,
+    scrollViewStyle?: StyleProp<ViewStyle>
     // Customize the View container.
     containerStyle?: StyleProp<ViewStyle>
     // Only load current index slide , loadMinimalSize slides before and after.


### PR DESCRIPTION
### Is it a bugfix ?
- Yes
Not direct related but https://github.com/leecade/react-native-swiper/issues/616
adding this will allow the next card preview 
```
<Swiper
  scrollViewStyle={{ overflow: 'visible' }}
  removeClippedSubviews={false}
  ...
```

### Is it a new feature ?
- no 

### Describe what you've done:
Add missing type for scrollViewStyle

